### PR TITLE
Fix PHP bug when no parameter hint in function statment.

### DIFF
--- a/lib/PHPParser/NodeVisitor/NameResolver.php
+++ b/lib/PHPParser/NodeVisitor/NameResolver.php
@@ -57,7 +57,10 @@ class PHPParser_NodeVisitor_NameResolver extends PHPParser_NodeVisitorAbstract
         ) {
             $node->name = $this->resolveOtherName($node->name);
         } elseif ($node instanceof PHPParser_Node_Param) {
-            $node->type = $this->resolveClassName($node->type);
+            if (!is_null($node->type))
+            {
+                $node->type = $this->resolveClassName($node->type);
+            }            
         }
     }
 


### PR DESCRIPTION
NameResolver caused PHP bug:

Catchable fatal error: Argument 1 passed to PHPParser_NodeVisitor_NameResolver::resolveClassName() must implement interface PHPParser_Node, null given

when no parameter hint was specified in function statment.

It's my first pull request on github, so i'm sorry if i did something wrong :)
