### PR TITLE
Add line number information to comments

### DIFF
--- a/lib/PHPParser/Comment.php
+++ b/lib/PHPParser/Comment.php
@@ -4,13 +4,17 @@ class PHPParser_Comment
 {
     protected $text;
 
+    protected $line;
+
     /**
      * Constructs a comment node.
      *
      * @param string $text Comment text (including comment delimiters like /*)
+     * @param int $line Line number the comment started on
      */
-    public function __construct($text) {
+    public function __construct($text, $line) {
         $this->text = $text;
+        $this->line = $line;
     }
 
     /**
@@ -29,6 +33,15 @@ class PHPParser_Comment
      */
     public function setText($text) {
         $this->text = $text;
+    }
+
+    /**
+     * Gets the line number the comment started on.
+     *
+     * @return int Line number
+     */
+    public function getLine() {
+        return $this->line;
     }
 
     /**

--- a/lib/PHPParser/Lexer.php
+++ b/lib/PHPParser/Lexer.php
@@ -102,9 +102,9 @@ class PHPParser_Lexer
                 $this->line += substr_count($token[1], "\n");
 
                 if (T_COMMENT === $token[0]) {
-                    $startAttributes['comments'][] = new PHPParser_Comment($token[1]);
+                    $startAttributes['comments'][] = new PHPParser_Comment($token[1], $token[2]);
                 } elseif (T_DOC_COMMENT === $token[0]) {
-                    $startAttributes['comments'][] = new PHPParser_Comment_Doc($token[1]);
+                    $startAttributes['comments'][] = new PHPParser_Comment_Doc($token[1], $token[2]);
                 } elseif (!isset($this->dropTokens[$token[0]])) {
                     $value = $token[1];
                     $startAttributes['startLine'] = $token[2];

--- a/lib/PHPParser/Serializer/XML.php
+++ b/lib/PHPParser/Serializer/XML.php
@@ -50,6 +50,7 @@ class PHPParser_Serializer_XML implements PHPParser_Serializer
         } elseif ($node instanceof PHPParser_Comment) {
             $this->writer->startElement('comment');
             $this->writer->writeAttribute('isDocComment', $node instanceof PHPParser_Comment_Doc ? 'true' : 'false');
+            $this->writer->writeAttribute('line', $node->getLine());
             $this->writer->text($node->getText());
             $this->writer->endElement();
         } elseif (is_array($node)) {

--- a/lib/PHPParser/Unserializer/XML.php
+++ b/lib/PHPParser/Unserializer/XML.php
@@ -125,6 +125,9 @@ class PHPParser_Unserializer_XML implements PHPParser_Unserializer
             ? 'PHPParser_Comment_Doc'
             : 'PHPParser_Comment'
         ;
-        return new $className($this->reader->readString());
+        return new $className(
+            $this->reader->readString(),
+            $this->reader->getAttribute('line')
+        );
     }
 }

--- a/test/PHPParser/Tests/CommentTest.php
+++ b/test/PHPParser/Tests/CommentTest.php
@@ -3,7 +3,7 @@
 class PHPParser_Tests_CommentTest extends PHPUnit_Framework_TestCase
 {
     public function testGetSetText() {
-        $comment = new PHPParser_Comment('/* Some comment */');
+        $comment = new PHPParser_Comment('/* Some comment */', 1);
 
         $this->assertEquals('/* Some comment */', $comment->getText());
         $this->assertEquals('/* Some comment */', (string) $comment);
@@ -18,7 +18,7 @@ class PHPParser_Tests_CommentTest extends PHPUnit_Framework_TestCase
      * @dataProvider provideTestReformatting
      */
     public function testReformatting($commentText, $reformattedText) {
-        $comment = new PHPParser_Comment($commentText);
+        $comment = new PHPParser_Comment($commentText, 1);
         $this->assertEquals($reformattedText, $comment->getReformattedText());
     }
 

--- a/test/PHPParser/Tests/LexerTest.php
+++ b/test/PHPParser/Tests/LexerTest.php
@@ -83,7 +83,7 @@ class PHPParser_Tests_LexerTest extends PHPUnit_Framework_TestCase
                         ord('$'), '$',
                         array(
                             'startLine' => 3,
-                            'comments' => array(new PHPParser_Comment_Doc('/** doc' . "\n" . 'comment */'))
+                            'comments' => array(new PHPParser_Comment_Doc('/** doc' . "\n" . 'comment */', 2))
                         ),
                         array('endLine' => 3)
                     ),
@@ -98,10 +98,10 @@ class PHPParser_Tests_LexerTest extends PHPUnit_Framework_TestCase
                         array(
                             'startLine' => 2,
                             'comments' => array(
-                                new PHPParser_Comment('/* comment */'),
-                                new PHPParser_Comment('// comment' . "\n"),
-                                new PHPParser_Comment_Doc('/** docComment 1 */'),
-                                new PHPParser_Comment_Doc('/** docComment 2 */'),
+                                new PHPParser_Comment('/* comment */', 1),
+                                new PHPParser_Comment('// comment' . "\n", 1),
+                                new PHPParser_Comment_Doc('/** docComment 1 */', 2),
+                                new PHPParser_Comment_Doc('/** docComment 2 */', 2),
                             ),
                         ),
                         array('endLine' => 2)

--- a/test/PHPParser/Tests/NodeAbstractTest.php
+++ b/test/PHPParser/Tests/NodeAbstractTest.php
@@ -6,8 +6,8 @@ class PHPParser_Tests_NodeAbstractTest extends PHPUnit_Framework_TestCase
         $attributes = array(
             'startLine' => 10,
             'comments'  => array(
-                new PHPParser_Comment('// Comment' . "\n"),
-                new PHPParser_Comment_Doc('/** doc comment */'),
+                new PHPParser_Comment('// Comment' . "\n", 8),
+                new PHPParser_Comment_Doc('/** doc comment */', 9),
             ),
         );
 

--- a/test/PHPParser/Tests/Serializer/XMLTest.php
+++ b/test/PHPParser/Tests/Serializer/XMLTest.php
@@ -21,9 +21,9 @@ CODE;
   <node:Stmt_Function>
    <attribute:comments>
     <scalar:array>
-     <comment isDocComment="false">// comment
+     <comment isDocComment="false" line="2">// comment
 </comment>
-     <comment isDocComment="true">/** doc comment */</comment>
+     <comment isDocComment="true" line="3">/** doc comment */</comment>
     </scalar:array>
    </attribute:comments>
    <attribute:startLine>

--- a/test/PHPParser/Tests/Unserializer/XMLTest.php
+++ b/test/PHPParser/Tests/Unserializer/XMLTest.php
@@ -12,9 +12,9 @@ class PHPParser_Tests_Unserializer_XMLTest extends PHPUnit_Framework_TestCase
   </attribute:startLine>
   <attribute:comments>
    <scalar:array>
-    <comment isDocComment="false">// comment
+    <comment isDocComment="false" line="2">// comment
 </comment>
-    <comment isDocComment="true">/** doc comment */</comment>
+    <comment isDocComment="true" line="3">/** doc comment */</comment>
    </scalar:array>
   </attribute:comments>
   <subNode:value>
@@ -29,8 +29,8 @@ XML;
             new PHPParser_Node_Scalar_String('Test', array(
                 'startLine' => 1,
                 'comments'  => array(
-                    new PHPParser_Comment('// comment' . "\n"),
-                    new PHPParser_Comment_Doc('/** doc comment */'),
+                    new PHPParser_Comment('// comment' . "\n", 2),
+                    new PHPParser_Comment_Doc('/** doc comment */', 3),
                 ),
             )),
             $unserializer->unserialize($xml)


### PR DESCRIPTION
Currently comments stored in the tree contain no information other than their text. It could be useful if they also stored the line number that the comment started on.

For example, phpDocumentor tries to get line numbers for documentation, but currently it has to fall back to using the line number of the associated node.
