### PR TITLE
Change to SPDX License Identifier (BSD-3-Clause) for composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "A PHP parser written in PHP",
     "keywords": ["php", "parser"],
     "type": "library",
-    "license": "BSD",
+    "license": "BSD-3-Clause",
     "authors": [
         {
             "name": "Nikita Popov"


### PR DESCRIPTION
The `composer validate` command is now supporting [SPDX license identifers](http://spdx.org/licenses/).

As your package is used within other codebases (and has a composer.json file) I kindly ask you to change the license identifier in composer.json from `BSD` to `BSD-3-Clause` ([_BSD 3-clause "New" or "Revised" License_](http://spdx.org/licenses/BSD-3-Clause)).

This suggestion has been done in good faith and is not a change of the license, just the way how it is identified. See as well [composer.json license property](http://getcomposer.org/doc/04-schema.md#license).

---

License text: [`LICENSE` file](https://github.com/nikic/PHP-Parser/blob/d94cd1998bb1fa4522c020e573f451aa608c1463/LICENSE) d94cd1998bb1fa4522c020e573f451aa608c1463
