### PR TITLE
adds ability to print out original names

### DIFF
--- a/lib/PHPParser/NodeVisitor/NameResolver.php
+++ b/lib/PHPParser/NodeVisitor/NameResolver.php
@@ -96,6 +96,8 @@ class PHPParser_NodeVisitor_NameResolver extends PHPParser_NodeVisitorAbstract
             return $name;
         }
 
+        $origName = clone $name;
+
         // resolve aliases (for non-relative names)
         if (!$name->isRelative() && isset($this->aliases[$name->getFirst()])) {
             $name->setFirst($this->aliases[$name->getFirst()]);
@@ -104,7 +106,10 @@ class PHPParser_NodeVisitor_NameResolver extends PHPParser_NodeVisitorAbstract
             $name->prepend($this->namespace);
         }
 
-        return new PHPParser_Node_Name_FullyQualified($name->parts, $name->getAttributes());
+        $fqn = new PHPParser_Node_Name_FullyQualified($name->parts, $name->getAttributes());
+        $fqn->setAttribute('original_name', $origName);
+
+        return $fqn;
     }
 
     protected function resolveOtherName(PHPParser_Node_Name $name) {
@@ -114,6 +119,8 @@ class PHPParser_NodeVisitor_NameResolver extends PHPParser_NodeVisitorAbstract
             return $name;
         }
 
+        $origName = clone $name;
+
         // resolve aliases for qualified names
         if ($name->isQualified() && isset($this->aliases[$name->getFirst()])) {
             $name->setFirst($this->aliases[$name->getFirst()]);
@@ -122,7 +129,10 @@ class PHPParser_NodeVisitor_NameResolver extends PHPParser_NodeVisitorAbstract
             $name->prepend($this->namespace);
         }
 
-        return new PHPParser_Node_Name_FullyQualified($name->parts, $name->getAttributes());
+        $fqn = new PHPParser_Node_Name_FullyQualified($name->parts, $name->getAttributes());
+        $fqn->setAttribute('original_name', $origName);
+
+        return $fqn;
     }
 
     protected function addNamespacedName(PHPParser_Node $node) {

--- a/lib/PHPParser/PrettyPrinter/Zend.php
+++ b/lib/PHPParser/PrettyPrinter/Zend.php
@@ -2,6 +2,13 @@
 
 class PHPParser_PrettyPrinter_Zend extends PHPParser_PrettyPrinterAbstract
 {
+    private $preserveOriginalNames = false;
+
+    public function setPreserveOriginalNames($bool)
+    {
+        $this->preserveOriginalNames = (boolean) $bool;
+    }
+
     // Special nodes
 
     public function pParam(PHPParser_Node_Param $node) {
@@ -26,6 +33,12 @@ class PHPParser_PrettyPrinter_Zend extends PHPParser_PrettyPrinterAbstract
     }
 
     public function pName_FullyQualified(PHPParser_Node_Name_FullyQualified $node) {
+        // Print out the name that was originally present in the source document
+        // if we replaced it during parsing.
+        if ($this->preserveOriginalNames && null !== $origName = $node->getAttribute('original_name')) {
+            return $this->p($origName);
+        }
+
         return '\\' . implode('\\', $node->parts);
     }
 

--- a/test/PHPParser/Tests/NodeVisitor/NameResolverTest.php
+++ b/test/PHPParser/Tests/NodeVisitor/NameResolverTest.php
@@ -84,6 +84,50 @@ EOC;
         $this->assertEquals($expectedCode, $prettyPrinter->prettyPrint($stmts));
     }
 
+    public function testPreservesOriginalName()
+    {
+        $code = <<<EOC
+<?php
+
+namespace Foo;
+
+class A { }
+
+namespace Bar;
+
+use Foo\A as Baz;
+
+class A extends Baz { }
+EOC;
+
+        $expectedCode = <<<EOC
+namespace Foo {
+    class A
+    {
+        
+    }
+}
+namespace Bar {
+    use Foo\A as Baz;
+    class A extends Baz
+    {
+        
+    }
+}
+EOC;
+
+        $parser        = new PHPParser_Parser(new PHPParser_Lexer_Emulative);
+        $prettyPrinter = new PHPParser_PrettyPrinter_Zend;
+        $prettyPrinter->setPreserveOriginalNames(true);
+        $traverser     = new PHPParser_NodeTraverser;
+        $traverser->addVisitor(new PHPParser_NodeVisitor_NameResolver);
+
+        $stmts = $parser->parse($code);
+        $stmts = $traverser->traverse($stmts);
+
+        $this->assertEquals($expectedCode, $prettyPrinter->prettyPrint($stmts));
+    }
+
     /**
      * @covers PHPParser_NodeVisitor_NameResolver
      */


### PR DESCRIPTION
Currently, if you are using the NameResolver, and then pretty print the result, all names are printed as their fully qualified versions (where available).

This patch adds the ability to also print the names as present in the source document (disabled by default to preserve BC).
