### PR TITLE
Add branch-alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,5 +14,10 @@
     },
     "autoload": {
         "psr-0": { "PHPParser": "lib/" }
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "0.9-dev"
+        }
     }
 }


### PR DESCRIPTION
This allows "0.9.*" or "~0.9" to install the dev version, if the
consumer allows for dev versions to be installed.
