### PR TITLE
Improve performance of PrettyPrinter

### DIFF
--- a/lib/PHPParser/PrettyPrinterAbstract.php
+++ b/lib/PHPParser/PrettyPrinterAbstract.php
@@ -66,7 +66,7 @@ abstract class PHPParser_PrettyPrinterAbstract
     protected $canUseSemicolonNamespaces;
 
     public function __construct() {
-        $this->noIndentToken = uniqid('_NO_INDENT_');
+        $this->noIndentToken = '_NO_INDENT_'.microtime();
     }
 
     /**


### PR DESCRIPTION
uniq_id is a _terribly_ slow function, and as it seems is only used
to generate a random non-occurring value. As such I replaced it 
with a similar statement that is far less unique but should do
the same in a fraction of the time.
