### PR TITLE
Feature request and implementation for NodeTraverser::removeVisitor

### DIFF
--- a/lib/PHPParser/NodeTraverser.php
+++ b/lib/PHPParser/NodeTraverser.php
@@ -24,6 +24,19 @@ class PHPParser_NodeTraverser implements PHPParser_NodeTraverserInterface
     }
 
     /**
+     * Removes an added visitor.
+     *
+     * @param PHPParser_NodeVisitor $visitor
+     */
+    public function removeVisitor(PHPParser_NodeVisitor $visitor) {
+        foreach($this->visitors as $index => $storedVisitor) {
+            if ($storedVisitor === $visitor) {
+                unset($this->visitors[$index]);
+            }
+        }
+    }
+
+    /**
      * Traverses an array of nodes using the registered visitors.
      *
      * @param PHPParser_Node[] $nodes Array of nodes

--- a/lib/PHPParser/NodeTraverserInterface.php
+++ b/lib/PHPParser/NodeTraverserInterface.php
@@ -10,6 +10,14 @@ interface PHPParser_NodeTraverserInterface
     function addVisitor(PHPParser_NodeVisitor $visitor);
 
     /**
+     * Removes an added visitor.
+     *
+     * @param PHPParser_NodeVisitor $visitor
+     *
+     */
+    function removeVisitor(PHPParser_NodeVisitor $visitor);
+
+    /**
      * Traverses an array of nodes using the registered visitors.
      *
      * @param PHPParser_Node[] $nodes Array of nodes

--- a/test/PHPParser/Tests/NodeTraverserTest.php
+++ b/test/PHPParser/Tests/NodeTraverserTest.php
@@ -122,4 +122,25 @@ class PHPParser_Tests_NodeTraverserTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals($stmts, $traverser->traverse($stmts));
     }
+
+    public function testRemovingVisitor() {
+        $visitor1 = $this->getMock('PHPParser_NodeVisitor');
+        $visitor2 = $this->getMock('PHPParser_NodeVisitor');
+        $visitor3 = $this->getMock('PHPParser_NodeVisitor');
+
+        $traverser = new PHPParser_NodeTraverser;
+        $traverser->addVisitor($visitor1);
+        $traverser->addVisitor($visitor2);
+        $traverser->addVisitor($visitor3);
+
+        $preExpected = array($visitor1, $visitor2, $visitor3);
+        $this->assertAttributeSame($preExpected, 'visitors', $traverser, 'The appropriate visitors have not been added');
+
+        $traverser->removeVisitor($visitor2);
+
+        $postExpected = array(0 => $visitor1, 2 => $visitor3);
+        $this->assertAttributeSame($postExpected, 'visitors', $traverser, 'The appropriate visitors are not present after removal');
+    }
+
+
 }


### PR DESCRIPTION
This pull request adds a test and implementation for removing an added `PHPParser_NodeVisitor` to a `PHPParser_NodeTraverser`. You pass a `NodeVisitor` as the first argument to the method and any added visitors strictly (`===`) matching that object will be removed. A side effect of this is that the visitors array's indices may become unordered but this doesn't appear to be a problem as I didn't see anyplace where you were relying on that.

I realize this alters an interface and might not be quickly merged in but I think it provides some useful functionality and allows better control over what visitors a traverser will wind up invoking.

---
## Use Case

Running static analysis on function use in a set of files.

``` php
<?php

class AnalysisVisitor extends PHPParser_NodeAbstract {

    private $nodes = [];

    public function enterNode(PHPParser_Node $node) {
        // do your check to store $node in $this->nodes
    }

    public function getNodes() {
        return $this->nodes;
    }

}

class Analyzer {

    private $parser;
    private $traverser;

    public function __construct(PHPParser_Parser $parser, PHPParser_NodeTraverserInterface $traverser) {
        $this->parser = $parser;
        $this->traverser = $traverser;
    }

    public function analyze($code) {
        $visitor = new AnalysisVisitor();
        $stmts = $this->parser->parse($code);
        $stmts = $this->traverser->traverse($stmts);

        // do your analysis from $visitor->getNodes();
        // after analysis

        $this->traverser->removeVisitor($visitor);
        return $somethingFromAnalysis;
    }

}
```

With the ::removeVisitor method we can use the same Parser and NodeTraverser instance for each call to Analyzer::analyze while ensuring that each piece of code examined gets its own visitor and ultimately its own collection of nodes analyzed. You could even return the $visitor from the above method to act as a data store of the nodes that we looked at. Another use case (which I can flesh out if you want) is setting a series of multiple visitors while needing to remove one and keep the rest. Without a way to remove the visitor you need to instantiate a traverser object again and reset the visitors.

Additionally this is in part about the completeness of the API. I don't see any reason we shouldn't be able to remove a Visitor.
