### PR TITLE
Fix name resolver (class names are case insensitive)

### DIFF
--- a/lib/PHPParser/NodeVisitor/NameResolver.php
+++ b/lib/PHPParser/NodeVisitor/NameResolver.php
@@ -22,7 +22,8 @@ class PHPParser_NodeVisitor_NameResolver extends PHPParser_NodeVisitorAbstract
             $this->namespace = $node->name;
             $this->aliases   = array();
         } elseif ($node instanceof PHPParser_Node_Stmt_UseUse) {
-            if (isset($this->aliases[$node->alias])) {
+            $aliasName = strtolower($node->alias);
+            if (isset($this->aliases[$aliasName])) {
                 throw new PHPParser_Error(
                     sprintf(
                         'Cannot use "%s" as "%s" because the name is already in use',
@@ -32,7 +33,7 @@ class PHPParser_NodeVisitor_NameResolver extends PHPParser_NodeVisitorAbstract
                 );
             }
 
-            $this->aliases[$node->alias] = $node->name;
+            $this->aliases[$aliasName] = $node->name;
         } elseif ($node instanceof PHPParser_Node_Stmt_Class) {
             if (null !== $node->extends) {
                 $node->extends = $this->resolveClassName($node->extends);
@@ -97,8 +98,9 @@ class PHPParser_NodeVisitor_NameResolver extends PHPParser_NodeVisitorAbstract
         }
 
         // resolve aliases (for non-relative names)
-        if (!$name->isRelative() && isset($this->aliases[$name->getFirst()])) {
-            $name->setFirst($this->aliases[$name->getFirst()]);
+        $aliasName = strtolower($name->getFirst());
+        if (!$name->isRelative() && isset($this->aliases[$aliasName])) {
+            $name->setFirst($this->aliases[$aliasName]);
         // if no alias exists prepend current namespace
         } elseif (null !== $this->namespace) {
             $name->prepend($this->namespace);
@@ -115,8 +117,9 @@ class PHPParser_NodeVisitor_NameResolver extends PHPParser_NodeVisitorAbstract
         }
 
         // resolve aliases for qualified names
-        if ($name->isQualified() && isset($this->aliases[$name->getFirst()])) {
-            $name->setFirst($this->aliases[$name->getFirst()]);
+        $aliasName = strtolower($name->getFirst());
+        if ($name->isQualified() && isset($this->aliases[$aliasName])) {
+            $name->setFirst($this->aliases[$aliasName]);
         // prepend namespace for relative names
         } elseif (null !== $this->namespace) {
             $name->prepend($this->namespace);

--- a/test/PHPParser/Tests/NodeVisitor/NameResolverTest.php
+++ b/test/PHPParser/Tests/NodeVisitor/NameResolverTest.php
@@ -222,4 +222,25 @@ EOC;
         $traverser->addVisitor(new PHPParser_NodeVisitor_NameResolver);
         $traverser->traverse($stmts);
     }
+
+    public function testClassNameIsCaseInsensitive()
+    {
+        $source = <<<EOC
+<?php
+namespace Foo;
+use Bar\\Baz;
+\$test = new baz();
+EOC;
+
+        $parser = new PHPParser_Parser(new PHPParser_Lexer_Emulative);
+        $stmts = $parser->parse($source);
+
+        $traverser = new PHPParser_NodeTraverser;
+        $traverser->addVisitor(new PHPParser_NodeVisitor_NameResolver);
+
+        $stmts = $traverser->traverse($stmts);
+        $stmt = $stmts[0];
+
+        $this->assertEquals(array('Bar', 'Baz'), $stmt->stmts[1]->expr->class->parts);
+    }
 }


### PR DESCRIPTION
PHP class names are not case sensitive.
This pull request fixes `PHPParser_NodeVisitor_NameResolver` class to match this rule.
