### PR TITLE
Ensure no registered error handler will see the 'reset' error

### DIFF
--- a/lib/PHPParser/Lexer.php
+++ b/lib/PHPParser/Lexer.php
@@ -41,7 +41,7 @@ class PHPParser_Lexer
 
     protected function resetErrors() {
         // set error_get_last() to defined state by forcing an undefined variable error
-        set_error_handler(function(){},0);
+        set_error_handler(create_function('',''),0);
         @$undefinedVariable;
         restore_error_handler();
     }


### PR DESCRIPTION
The current implementation in the default Lexer triggers a (suppressed) notice to force error_get_last() into a "known" default state. While that technically doesn't clear any error but rather "overwrites" whatever other error might have been on the stack, the current implementation conflicts with potentially registered strict error handlers where every error gets converted into an exception.

This PR fixes that by registering a temporary error handler before triggering the error, followed by a direct removal and thus restoring the previous handler.
