### PR TITLE
Add name attribute on magic constants

### DIFF
--- a/lib/PhpParser/Node/Scalar/MagicConst.php
+++ b/lib/PhpParser/Node/Scalar/MagicConst.php
@@ -3,6 +3,7 @@
 namespace PhpParser\Node\Scalar;
 
 use PhpParser\Node\Scalar;
+use PhpParser\Node\Name;
 
 abstract class MagicConst extends Scalar
 {
@@ -12,6 +13,14 @@ abstract class MagicConst extends Scalar
      * @param array $attributes Additional attributes
      */
     public function __construct(array $attributes = array()) {
-        parent::__construct(array(), $attributes);
+        $name = explode('\\', get_class($this));
+        $name = trim(strtoupper(array_pop($name)), '_');
+
+        parent::__construct(
+            array(
+                'name' => new Name(sprintf('__%s__', $name))
+            ),
+            $attributes
+        );
     }
 }

--- a/test/PhpParser/Node/Scalar/MagicConstTest.php
+++ b/test/PhpParser/Node/Scalar/MagicConstTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace PhpParser\Node\Scalar;
+
+class MagicConstTest extends \PHPUnit_Framework_TestCase
+{
+    public function testClassConstruct() {
+        $node = new MagicConst\Class_();
+        $this->assertEquals(array('__CLASS__'), $node->name->parts);
+    }
+
+    public function testDirConstruct() {
+        $node = new MagicConst\Dir();
+        $this->assertEquals(array('__DIR__'), $node->name->parts);
+    }
+
+    public function testFileConstruct() {
+        $node = new MagicConst\File();
+        $this->assertEquals(array('__FILE__'), $node->name->parts);
+    }
+
+    public function testLineConstruct() {
+        $node = new MagicConst\Line();
+        $this->assertEquals(array('__LINE__'), $node->name->parts);
+    }
+
+    public function testMethodConstruct() {
+        $node = new MagicConst\Method();
+        $this->assertEquals(array('__METHOD__'), $node->name->parts);
+    }
+
+    public function testNamespaceConstruct() {
+        $node = new MagicConst\Namespace_();
+        $this->assertEquals(array('__NAMESPACE__'), $node->name->parts);
+    }
+
+    public function testTraitConstruct() {
+        $node = new MagicConst\Trait_();
+        $this->assertEquals(array('__TRAIT__'), $node->name->parts);
+    }
+}


### PR DESCRIPTION
Here is a little contribution to add automatic name on magic constant nodes.

With unit tests 
    PHPUnit 3.7.31 by Sebastian Bergmann.

```
.......

Time: 187 ms, Memory: 2.00Mb

OK (7 tests, 7 assertions)
```

Here is a sample of result in real condition

```
[args] => Array
    (
        [0] => PhpParser\Node\Arg Object
            (
                [subNodes:protected] => Array
                    (
                        [value] => PhpParser\Node\Scalar\MagicConst\File Object
                            (
                                [subNodes:protected] => Array
                                    (
                                        [name] => PhpParser\Node\Name Object
                                            (
                                                [subNodes:protected] => Array
                                                    (
                                                        [parts] => Array
                                                                    (
                                                                        [0] => __FILE__
                                                                    )

                                                            )

                                                        [attributes:protected] => Array
                                                            (
                                                            )

                                                    )

                                            )

                                        [attributes:protected] => Array
                                            (
                                                [startLine] => 185
                                                [endLine] => 185
                                            )

                                    )

                                [byRef] => 
                            )

                        [attributes:protected] => Array
                            (
                                [startLine] => 185
                                [endLine] => 185
                            )

                    )

            )
```

BTW, thanks for your parser, its really a pleasure to implement it. I did it only on one day to replace my old parser in my PHP Reflect v2 project.
