### PR TITLE
Pretty printer correctly prints negative floats

### DIFF
--- a/lib/PhpParser/PrettyPrinter/Standard.php
+++ b/lib/PhpParser/PrettyPrinter/Standard.php
@@ -98,7 +98,7 @@ class Standard extends PrettyPrinterAbstract
         $stringValue = (string) $node->value;
 
         // ensure that number is really printed as float
-        return ctype_digit($stringValue) ? $stringValue . '.0' : $stringValue;
+        return preg_match('/^-?[0-9]+$/', $stringValue) ? $stringValue . '.0' : $stringValue;
     }
 
     // Assignments


### PR DESCRIPTION
When float number is something like -5 pretty printer produces -5.0 instead of -5 
