### PR TITLE
Preserve shebang (T_INLINE_HTML) without opening php tag

### DIFF
--- a/lib/PhpParser/PrettyPrinter/Standard.php
+++ b/lib/PhpParser/PrettyPrinter/Standard.php
@@ -701,7 +701,11 @@ class Standard extends PrettyPrinterAbstract
     }
 
     public function pStmt_InlineHTML(Stmt\InlineHTML $node) {
-        return '?>' . $this->pNoIndent("\n" . $node->value) . '<?php ';
+        if (strpos($node->value, '#!') === 0) {
+          return $this->pNoIndent("\n" . $node->value) . '<?php ';
+        } else {
+          return '?>' . $this->pNoIndent("\n" . $node->value) . '<?php ';
+        }
     }
 
     public function pStmt_HaltCompiler(Stmt\HaltCompiler $node) {

--- a/test/code/prettyPrinter/shebang.test
+++ b/test/code/prettyPrinter/shebang.test
@@ -1,0 +1,11 @@
+Shebang
+-----
+#!/usr/bin/env php
+<?php
+error_reporting(E_ALL ^ E_STRICT);
+require_once __DIR__ . '/vendor/autoload.php';
+-----
+#!/usr/bin/env php
+<?php
+error_reporting(E_ALL ^ E_STRICT);
+require_once __DIR__ . '/vendor/autoload.php';


### PR DESCRIPTION
Probably not the elegant way to do it. If this is out of the scope of the parser, please close & ignore pull request.
