### PR TITLE
add print_r dump operation to bin Script

### DIFF
--- a/bin/php-parse.php
+++ b/bin/php-parse.php
@@ -50,6 +50,9 @@ foreach ($files as $file) {
         } elseif ('var-dump' === $operation) {
             echo "==> var_dump():\n";
             var_dump($stmts);
+        } elseif ('print-r' === $operation) {
+            echo "==> print_r():\n";
+            print_r($stmts);
         } elseif ('resolve-names' === $operation) {
             echo "==> Resolved names.\n";
             $stmts = $traverser->traverse($stmts);
@@ -70,6 +73,7 @@ Operations is a list of the following options (--dump by default):
     --pretty-print   -p  Pretty print file using PrettyPrinter\Standard
     --serialize-xml      Serialize nodes using Serializer\XML
     --var-dump           var_dump() nodes (for exact structure)
+    --print-r            print_r() nodes (for exact structure)
     --resolve-names  -N  Resolve names using NodeVisitor\NameResolver
 
 Example:
@@ -107,6 +111,9 @@ function parseArgs($args) {
                 break;
             case '--var-dump':
                 $operations[] = 'var-dump';
+                break;
+            case '--print-r':
+                $operations[] = 'print-r';
                 break;
             case '--resolve-names':
             case '-N';


### PR DESCRIPTION
While I wanted to explore a source code that have at least this source code 

``` php
$this->$method();
```

I used for the first time the `bin/php-parse.php` script and try to dump contents of nodes with `--var-dump` operation.

It gave me too little info (for my point of view). See output as follow. 

```
==> var_dump():
array(1) {
  [0] =>
  class PhpParser\Node\Expr\MethodCall#12 (2) {
    protected $subNodes =>
    array(3) {
      'var' =>
      class PhpParser\Node\Expr\Variable#13 (2) {
        ...
      }
      'name' =>
      class PhpParser\Node\Expr\Variable#14 (2) {
        ...
      }
      'args' =>
      array(0) {
        ...
      }
    }
    protected $attributes =>
    array(2) {
      'startLine' =>
      int(2)
      'endLine' =>
      int(2)
    }
  }
}
```

I would like to have all details, so I've added a new operation called  `--print-r`, that gave me following output

```
==> print_r():
Array
(
    [0] => PhpParser\Node\Expr\MethodCall Object
        (
            [subNodes:protected] => Array
                (
                    [var] => PhpParser\Node\Expr\Variable Object
                        (
                            [subNodes:protected] => Array
                                (
                                    [name] => this
                                )

                            [attributes:protected] => Array
                                (
                                    [startLine] => 2
                                    [endLine] => 2
                                )

                        )

                    [name] => PhpParser\Node\Expr\Variable Object
                        (
                            [subNodes:protected] => Array
                                (
                                    [name] => method
                                )

                            [attributes:protected] => Array
                                (
                                    [startLine] => 2
                                    [endLine] => 2
                                )

                        )

                    [args] => Array
                        (
                        )

                )

            [attributes:protected] => Array
                (
                    [startLine] => 2
                    [endLine] => 2
                )

        )

)
```
