### PR TITLE
Add line returns

### DIFF
--- a/bin/php-parse.php
+++ b/bin/php-parse.php
@@ -91,6 +91,8 @@ Example:
     php php-parse.php -d -p -N -d file.php
 
     Dumps nodes, pretty prints them, then resolves names and dumps them again.
+
+
 OUTPUT
     );
 }


### PR DESCRIPTION
Add line returns to the help message so that the terminal won't end up on the same line.
