### PR TITLE
Lexer option

### DIFF
--- a/bin/php-parse.php
+++ b/bin/php-parse.php
@@ -9,7 +9,7 @@ ini_set('xdebug.var_display_max_children', -1);
 ini_set('xdebug.var_display_max_data', -1);
 ini_set('xdebug.var_display_max_depth', -1);
 
-list($operations, $files) = parseArgs($argv);
+list($lexer, $operations, $files) = parseArgs($argv);
 
 /* Dump nodes by default */
 if (empty($operations)) {
@@ -20,7 +20,7 @@ if (empty($files)) {
     showHelp("Must specify at least one file.");
 }
 
-$parser = new PhpParser\Parser(new PhpParser\Lexer\Emulative);
+$parser = new PhpParser\Parser(new $lexer);
 $dumper = new PhpParser\NodeDumper;
 $prettyPrinter = new PhpParser\PrettyPrinter\Standard;
 $serializer = new PhpParser\Serializer\XML;
@@ -85,6 +85,7 @@ Operations is a list of the following options (--dump by default):
     --serialize-xml      Serialize nodes using Serializer\XML
     --var-dump           var_dump() nodes (for exact structure)
     --resolve-names  -N  Resolve names using NodeVisitor\NameResolver
+    --lexer              Use another lexer than standard Lexer\Emulative
 
 Example:
 
@@ -100,6 +101,7 @@ OUTPUT
 function parseArgs($args) {
     $operations = array();
     $files = array();
+    $lexer = 'PhpParser\Lexer\Emulative';
 
     array_shift($args);
     $parseOptions = true;
@@ -132,7 +134,10 @@ function parseArgs($args) {
                 $parseOptions = false;
                 break;
             default:
-                if ($arg[0] === '-') {
+                if (strpos($arg, '--lexer=') === 0) {
+                    $parts = explode('=', $arg);
+                    $lexer = $parts[1];
+                } elseif ($arg[0] === '-') {
                     showHelp("Invalid operation $arg.");
                 } else {
                     $files[] = $arg;
@@ -140,5 +145,5 @@ function parseArgs($args) {
         }
     }
 
-    return array($operations, $files);
+    return array($lexer, $operations, $files);
 }

--- a/lib/PhpParser/Autoloader.php
+++ b/lib/PhpParser/Autoloader.php
@@ -32,6 +32,8 @@ class Autoloader
             if (isset(self::$oldToNewMap[$class])) {
                 self::registerLegacyAliases();
             }
+        } else if (stream_resolve_include_path($fileName = $class . '.php')) {
+            require $fileName;
         }
     }
 


### PR DESCRIPTION
This PR give ability to test the CLI version of the parser, using your own lexer.

For example, if you use a lexer like the one describe in [documentation](https://github.com/nikic/PHP-Parser/blob/master/doc/component/Lexer.markdown#user-content-token-offset-lexer), actually you can't test it with the CLI version without patching it.

Goal is to add a new option `--lexer` to select a new class that may be resolved in `include_path` through the standard PHP-Parser Autoloader 

Take an example. With a lexer as defined below

``` php
<?php

namespace Bartlett\PhpParser\Lexer;

/**
 *
 *
 * @author Nikita Popov
 * @author Christoph M. Becker
 * @link   https://gist.github.com/nikic/04fce01e69ae5b7b44f8
 * @link   https://github.com/nikic/PHP-Parser/issues/136
 */

class TokenOffsets extends \PhpParser\Lexer\Emulative
{
    public function getNextToken(&$value = null, &$startAttributes = null, &$endAttributes = null)
    {
        $token = parent::getNextToken($value, $startAttributes, $endAttributes);
        $startAttributes['startOffset'] = $endAttributes['endOffset'] = $this->pos;
        return $token;
    }

    public function getTokens()
    {
        return $this->tokens;
    }
}
```

That is resolvable in the include_path (via `stream_resolve_include_path` php function), here are how to dump nodes and show token offsets attributes provided by this lexer version.

```
$ php php-parse.php --lexer=Bartlett\PhpParser\Lexer\TokenOffsets --var-dump  file.php
```
