### PR TITLE
Add a a reference to PrettyPrinter to code generation doc

### DIFF
--- a/doc/4_Code_generation.markdown
+++ b/doc/4_Code_generation.markdown
@@ -36,10 +36,11 @@ $node = $factory->class('SomeClass')
 ;
 
 $stmts = array($node);
+$prettyPrinter = new \PhpParser\PrettyPrinter\Standard();
 echo $prettyPrinter->prettyPrint($stmts);
 ```
 
-This will produce the following output with the default pretty printer:
+This will produce the following output with the standard pretty printer:
 
 ```php
 <?php


### PR DESCRIPTION
The `$prettyPrinter` variable was undefined in the doc. 

Also, the PrettyPrinter was mentioned as `default`, but it's `Standard`, actually.
