### PR TITLE
Ensure compatibility with multiple composer autoloaders

### DIFF
--- a/lib/PhpParser/Autoloader.php
+++ b/lib/PhpParser/Autoloader.php
@@ -8,13 +8,24 @@ namespace PhpParser;
 class Autoloader
 {
     /**
+     * Whether the autoloader has been registered.
+     *
+     * @var boolean
+     */
+    protected static $registered = false;
+
+    /**
      * Registers PhpParser\Autoloader as an SPL autoloader.
      *
      * @param bool $prepend Whether to prepend the autoloader instead of appending
      */
     static public function register($prepend = false) {
+        if (static::$registered === true) {
+            return;
+        }
         ini_set('unserialize_callback_func', 'spl_autoload_call');
         spl_autoload_register(array(__CLASS__, 'autoload'), true, $prepend);
+        static::$registered = true;
     }
 
     /**

--- a/lib/bootstrap.php
+++ b/lib/bootstrap.php
@@ -1,4 +1,6 @@
 <?php
 
-require __DIR__ . '/PhpParser/Autoloader.php';
+if (!class_exists('PhpParser\Autoloader')) {
+    require __DIR__ . '/PhpParser/Autoloader.php';
+}
 PhpParser\Autoloader::register();


### PR DESCRIPTION
This is probably a really edge case but I think it's worth considering at least.

I'm working on a project that uses PHP-Parser to analyze code. This project can be executed via an executable PHP file or a Phar file. In both cases, a composer autoloader is registered and PHP-Parser's autoloader kicks in.

Then, to analyze the code of the project the user wants, the composer autoloader of the current working directory is also registered. This means there are two composer autoloaders working at the same time - which is usually OK, except the PHP-Parser autoloader always requires the Autoloader class file, causing a "cannot redeclare class" error.

Other than defining a constant (`define('PHP_PARSER_AUTOLOADER_LOADED', true)`), the only way to avoid loading the class file more than once is by doing a `class_exists()`. This invokes a bit of overhead, but it does only happen once each request at worst.