### PR TITLE
Added a flag to NodeTraverser to avoid cloning nodes

### DIFF
--- a/lib/PhpParser/NodeTraverser.php
+++ b/lib/PhpParser/NodeTraverser.php
@@ -10,10 +10,18 @@ class NodeTraverser implements NodeTraverserInterface
     protected $visitors;
 
     /**
-     * Constructs a node traverser.
+     * @var bool
      */
-    public function __construct() {
+    private $cloneNodes;
+
+    /**
+     * Constructs a node traverser.
+     *
+     * @param bool $cloneNodes Should the traverser clone the nodes when traversing the AST
+     */
+    public function __construct($cloneNodes = true) {
         $this->visitors = array();
+        $this->cloneNodes = $cloneNodes;
     }
 
     /**
@@ -65,7 +73,9 @@ class NodeTraverser implements NodeTraverserInterface
     }
 
     protected function traverseNode(Node $node) {
-        $node = clone $node;
+        if ($this->cloneNodes) {
+            $node = clone $node;
+        }
 
         foreach ($node->getSubNodeNames() as $name) {
             $subNode =& $node->$name;

--- a/test/PhpParser/NodeTraverserTest.php
+++ b/test/PhpParser/NodeTraverserTest.php
@@ -184,4 +184,20 @@ class NodeTraverserTest extends \PHPUnit_Framework_TestCase
         $postExpected = array(0 => $visitor1, 2 => $visitor3);
         $this->assertAttributeSame($postExpected, 'visitors', $traverser, 'The appropriate visitors are not present after removal');
     }
+
+    public function testCloneNodesByDefault() {
+        $stmts = array(new Node\Stmt\Echo_(array(new String_('Foo'), new String_('Bar'))));
+
+        $traverser = new NodeTraverser;
+
+        $this->assertNotSame($stmts, $traverser->traverse($stmts));
+    }
+
+    public function testCloneNodesDisabled() {
+        $stmts = array(new Node\Stmt\Echo_(array(new String_('Foo'), new String_('Bar'))));
+
+        $traverser = new NodeTraverser(false);
+
+        $this->assertSame($stmts, $traverser->traverse($stmts));
+    }
 }


### PR DESCRIPTION
Fixes #184

I added a flag to the constructor of `NodeTraverser` to disable the default behavior of cloning all nodes when traversing the AST.