### PR TITLE
Autoloader::register() has side effects even when the library is not used

### DIFF
--- a/lib/PhpParser/Autoloader.php
+++ b/lib/PhpParser/Autoloader.php
@@ -23,7 +23,6 @@ class Autoloader
             return;
         }
 
-        ini_set('unserialize_callback_func', 'spl_autoload_call');
         spl_autoload_register(array(__CLASS__, 'autoload'), true, $prepend);
         self::$registered = true;
         self::$runningOnPhp7 = version_compare(PHP_VERSION, '7.0-dev', '>=');

--- a/test/PhpParser/AutoloaderTest.php
+++ b/test/PhpParser/AutoloaderTest.php
@@ -38,4 +38,19 @@ class AutoloaderTest extends \PHPUnit_Framework_TestCase {
         $this->assertFalse(class_exists('PhpParser\FooBar'));
         $this->assertFalse(class_exists('PHPParser_FooBar'));
     }
+    
+    /**
+     * @test
+     * @runInSeparateProcess
+     * @dataProvider provideTestRunInSeparateProcess
+     */
+    public function testRunInSeparateProcess($mock) {
+        $this->assertTrue(true);
+    }
+    
+    public function provideTestRunInSeparateProcess() {
+        return array(
+            array($this->getMock("PhpParser\\AutoloaderTest"))
+        );
+    }
 }


### PR DESCRIPTION
Hi,
Do you by any chance remember the intention behind this in `Autoloader::register()` (83a2077f):

    ini_set('unserialize_callback_func', 'spl_autoload_call')

Well, it has side effects even if the library is not used. Composer will register the autoloader and break under some circumstances unit tests which don't use the library at all. I created one simple test case to present the issue. If you would run `AutoloaderTest::testRunInSeparateProcess()` with the original autoloader it would break. The funny thing, any project which just pulls in PHP-Parser can't have such unit tests.
I suggest to simply remove that line from the autoloader or at least don't turn that switch on by default.