### PR TITLE
Correct detection of implicitly public method nodes

### DIFF
--- a/lib/PhpParser/Node/Stmt/ClassMethod.php
+++ b/lib/PhpParser/Node/Stmt/ClassMethod.php
@@ -75,7 +75,7 @@ class ClassMethod extends Node\Stmt implements FunctionLike
     }
 
     public function isPublic() {
-        return ($this->type & Class_::MODIFIER_PUBLIC) !== 0 || $this->type === 0;
+        return ($this->type & Class_::MODIFIER_PUBLIC) !== 0 || (!$this->isPrivate() && !$this->isProtected());
     }
 
     public function isProtected() {

--- a/test/PhpParser/Node/Stmt/ClassMethodTest.php
+++ b/test/PhpParser/Node/Stmt/ClassMethodTest.php
@@ -36,4 +36,28 @@ class ClassMethodTest extends \PHPUnit_Framework_TestCase
             array('static'),
         );
     }
+
+    /**
+     * Checks that implicit public modifier detection for method is working
+     *
+     * @dataProvider implicitPublicModifiers
+     *
+     * @param integer $modifier Node type modifier
+     */
+    public function testImplicitPublic($modifier)
+    {
+        $node = new ClassMethod('foo', array(
+            'type' => constant('PhpParser\Node\Stmt\Class_::MODIFIER_' . strtoupper($modifier))
+        ));
+
+        $this->assertTrue($node->isPublic(), 'Node should be implicitly public');
+    }
+
+    public function implicitPublicModifiers() {
+        return array(
+            array('abstract'),
+            array('final'),
+            array('static'),
+        );
+    }
 }


### PR DESCRIPTION
Method nodes that have only one of `abstract`, `final` or `static` are not marked as public. Method should be considered public if it has explicit `public` modifier or it isn't private or protected.