### PR TITLE
Travis are not building php 7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,9 @@ php:
   - 5.5
   - 5.6
   - 7.0
-  - nightly
   - hhvm
 
 install: composer install
 
 matrix:
-  allow_failures:
-    - php: nightly
   fast_finish: true


### PR DESCRIPTION
https://github.com/travis-ci/php-src-builder/commit/17395d3214936af2ac92ccecc806e99b8863c332.

Nightly is still 7.0.