### PR TITLE
Implement ScopeResolver with tests and docs. Fixes #144, Extends #148.

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Component documentation:
 
  1. [Error](doc/component/Error.markdown)
  2. [Lexer](doc/component/Lexer.markdown)
+ 3. [ScopeResolver](doc/component/ScopeResolver.markdown)
 
  [doc_1_x]: https://github.com/nikic/PHP-Parser/tree/1.x/doc
  [doc_master]: https://github.com/nikic/PHP-Parser/tree/master/doc

--- a/doc/component/ScopeResolver.markdown
+++ b/doc/component/ScopeResolver.markdown
@@ -1,0 +1,71 @@
+ScopeResolver documentation
+===========================
+
+ScopeResolver is a default NodeVisitor for adding `scope` attributes to each of the nodes.
+
+Having a scope attribute handily available for every statement can be really useful, for example, when trying to
+figure out when a variable assignment goes out of scope.
+
+Usage
+-----
+
+Using ScopeResolver is extremely simple. There are no options, just add ScopeResolver to NodeTraverser
+and let it run. Here is an example:
+
+```php
+use PhpParser\ParserFactory;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitor\ScopeResolver;
+
+$parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7);
+$traverser = new NodeTraverser;
+
+$traverser->addVisitor(new ScopeResolver);
+
+try {
+    // read the file that should be converted
+    $code = file_get_contents($file);
+
+    // parse
+    $stmts = $parser->parse($code);
+
+    // traverse
+    $stmts = $traverser->traverse($stmts);
+
+    // see the results!
+    var_dump($stmts);
+} catch (PhpParser\Error $e) {
+    echo 'Parse Error: ', $e->getMessage();
+}
+```
+
+Now each of the nodes should have a `scope` attribute following the syntax form below.
+
+Syntax
+------
+
+In case you require additional information about a scope, it is given to you in an easily parsable string format.
+
+All scopes are prepended by `\`, which is the root namespace.
+
+All namespaces (without anything inside) end with `\` to indicate a raw namespace.
+
+Functions are appended by the function definition braces `()`.
+
+Class methods are prepended by the object operator `->`.
+
+Closures are essentially Closure classes, so they are treated as such in a namespace.  
+If inside a class or a function, or if they are nested, they are prepended by the scope resolution operator `::`.
+
+## Examples:
+
+Root namespace: `\`  
+Function `test()` inside the root namespace: `\test()`  
+Raw `Vendor\Package\Tester` namespace: `\Vendor\Package\Tester\`  
+Function `test()` inside the namespace: `\Vendor\Package\Tester\test()`  
+Class `TestClass` inside the namespace `\Vendor\Package\Tester\TestClass`  
+Class method `coverage()`: `\Vendor\Package\Tester\TestClass->coverage()`  
+A Closure inside the root namespace: `\Closure`  
+Nested Closures inside the root namespace: `\Closure::Closure::Closure`  
+A Closure inside namespaced function `test()`: `\Vendor\Package\Tester\test()::Closure::Closure`  
+A Closure inside namespaced class method `coverage()`: `\Vendor\Package\Tester\TestClass->coverage()::Closure`  

--- a/lib/PhpParser/NodeVisitor/ScopeResolver.php
+++ b/lib/PhpParser/NodeVisitor/ScopeResolver.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace PhpParser\NodeVisitor;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Stmt;
+use PhpParser\NodeVisitorAbstract;
+
+/**
+ * Class ScopeResolver
+ *
+ * @author Michael Yoo <michael@yoo.id.au>
+ * @author Bernhard Reiter <ockham@raz.or.at>
+ */
+class ScopeResolver extends NodeVisitorAbstract
+{
+    const SCOPE_SEPARATOR = '::';
+    const METHOD_SEPARATOR = '->';
+    const NAMESPACE_SEPARATOR = '\\';
+    const CLOSURE_DEFINITION = 'Closure';
+    const FUNCTION_DEFINITION = '()';
+
+    /** @var array The scope stack for the current node w/ root namespace '\' prepended */
+    protected $scope = [self::NAMESPACE_SEPARATOR];
+
+    public function enterNode(Node $node)
+    {
+        $node->setAttribute('scope', implode("", $this->scope));
+
+        if($node instanceof Stmt\Namespace_ and !empty($node->name))
+        {
+            $this->scope[] = $node->name.self::NAMESPACE_SEPARATOR;
+        }
+        elseif($node instanceof Stmt\Class_)
+        {
+            $this->scope[] = $node->name;
+        }
+        elseif($node instanceof Stmt\Function_)
+        {
+            $this->scope[] = $node->name.self::FUNCTION_DEFINITION;
+        }
+        elseif($node instanceof Stmt\ClassMethod)
+        {
+            $this->scope[] = self::METHOD_SEPARATOR.$node->name.self::FUNCTION_DEFINITION;
+        }
+        elseif($node instanceof Expr\Closure)
+        {
+            // Do not prepend '::' if appending namespace
+            if($x = array_values($this->scope) and $e = end($x) and substr($e, -1) === "\\")
+            {
+                $this->scope[] = self::CLOSURE_DEFINITION;
+            }
+            else
+            {
+                $this->scope[] = self::SCOPE_SEPARATOR.self::CLOSURE_DEFINITION;
+            }
+        }
+
+        return $node;
+    }
+
+    public function leaveNode(Node $node)
+    {
+        if(
+            // Do not array_pop the root namespace
+            ($node instanceof Stmt\NameSpace_ and count($this->scope) > 1)
+            or $node instanceof Stmt\Class_
+            or $node instanceof Stmt\ClassMethod
+            or $node instanceof Stmt\Function_
+            or $node instanceof Expr\Closure
+        )
+        {
+            array_pop($this->scope);
+        }
+    }
+}

--- a/test/PhpParser/NodeVisitor/ScopeResolverTest.php
+++ b/test/PhpParser/NodeVisitor/ScopeResolverTest.php
@@ -1,0 +1,308 @@
+<?php
+
+namespace PhpParser\NodeVisitor;
+
+use PhpParser;
+use PhpParser\Node\Stmt\Namespace_;
+use PhpParser\ParserFactory;
+use PhpParser\NodeTraverser;
+use PhpParser\Node;
+use PhpParser\Node\Name;
+use PhpParser\Node\Stmt;
+use PhpParser\Node\Expr;
+
+/**
+ * Class ScopeResolverTest
+ *
+ * @author Michael Yoo <michael@yoo.id.au>
+ */
+class ScopeResolverTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @covers PhpParser\NodeVisitor\NameResolver
+     * @dataProvider provideTestResolveScopes
+     */
+    public function testResolveScopes($namespace, $code, $result)
+    {
+        $parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7);
+        $traverser = new NodeTraverser;
+
+        $traverser->addVisitor(new ScopeResolver);
+
+        $stmts = $parser->parse($code);
+        $stmts = $traverser->traverse($stmts);
+
+        /** @var Namespace_ $namespaceNode */
+        $namespaceNode = $stmts[0];
+
+        //var_export($this->parseScopesRecursive($namespaceNode->stmts));
+
+        $this->assertNotNull(
+            $namespaceNode->getAttribute("scope"), "Attribute 'scope' does not exist! Is the test properly written?");
+        $this->assertEquals(
+            $namespace, $namespaceNode->stmts[0]->getAttribute("scope"), "Namespace node scope does not equal expected");
+
+        $this->assertEquals(
+            $result, $this->parseScopesRecursive($namespaceNode->stmts), "Expected scopes result mismatch");
+    }
+
+    public function provideTestResolveScopes()
+    {
+        return [
+            [
+                "namespace" => "\\",
+                "code" => "<?php\n\nnamespace {\n".self::CODE."\n}",
+                "result" => $this->resultTestResolveScopes("\\")
+            ],
+            [
+                "namespace" => "\\Vendor\\",
+                "code" => "<?php\n\nnamespace Vendor {\n".self::CODE."\n}",
+                "result" => $this->resultTestResolveScopes("\\Vendor\\")
+            ],
+            [
+                "namespace" => "\\Vendor\\Package\\",
+                "code" => "<?php\n\nnamespace Vendor\\Package {\n".self::CODE."\n}",
+                "result" => $this->resultTestResolveScopes("\\Vendor\\Package\\")
+            ],
+        ];
+    }
+
+    public function resultTestResolveScopes($namespace)
+    {
+        return [
+            0 =>
+                [
+                    'type' => 'Stmt_Use4',
+                    'scope' => $namespace,
+                ],
+            1 =>
+                [
+                    'type' => 'Stmt_UseUse4',
+                    'scope' => $namespace,
+                ],
+            2 =>
+                [
+                    'type' => 'Expr_Assign6',
+                    'scope' => $namespace,
+                ],
+            3 =>
+                [
+                    'type' => 'Stmt_Function8',
+                    'scope' => $namespace,
+                ],
+            4 =>
+                [
+                    'type' => 'Stmt_Return10',
+                    'scope' => $namespace.'test()',
+                ],
+            5 =>
+                [
+                    'type' => 'Expr_Closure10',
+                    'scope' => $namespace.'test()',
+                ],
+            6 =>
+                [
+                    'type' => 'Stmt_Return11',
+                    'scope' => $namespace.'test()::Closure',
+                ],
+            7 =>
+                [
+                    'type' => 'Scalar_String11',
+                    'scope' => $namespace.'test()::Closure',
+                ],
+            8 =>
+                [
+                    'type' => 'Stmt_Function15',
+                    'scope' => $namespace,
+                ],
+            9 =>
+                [
+                    'type' => 'Stmt_Return17',
+                    'scope' => $namespace.'nested()',
+                ],
+            10 =>
+                [
+                    'type' => 'Expr_Closure17',
+                    'scope' => $namespace.'nested()',
+                ],
+            11 =>
+                [
+                    'type' => 'Stmt_Return18',
+                    'scope' => $namespace.'nested()::Closure',
+                ],
+            12 =>
+                [
+                    'type' => 'Expr_Closure18',
+                    'scope' => $namespace.'nested()::Closure',
+                ],
+            13 =>
+                [
+                    'type' => 'Stmt_Return19',
+                    'scope' => $namespace.'nested()::Closure::Closure',
+                ],
+            14 =>
+                [
+                    'type' => 'Expr_Closure19',
+                    'scope' => $namespace.'nested()::Closure::Closure',
+                ],
+            15 =>
+                [
+                    'type' => 'Stmt_Return20',
+                    'scope' => $namespace.'nested()::Closure::Closure::Closure',
+                ],
+            16 =>
+                [
+                    'type' => 'Scalar_String20',
+                    'scope' => $namespace.'nested()::Closure::Closure::Closure',
+                ],
+            17 =>
+                [
+                    'type' => 'Stmt_Class26',
+                    'scope' => $namespace,
+                ],
+            18 =>
+                [
+                    'type' => 'Stmt_ClassMethod28',
+                    'scope' => $namespace.'TestClass',
+                ],
+            19 =>
+                [
+                    'type' => 'Stmt_Return30',
+                    'scope' => $namespace.'TestClass->coverage()',
+                ],
+            20 =>
+                [
+                    'type' => 'Expr_FuncCall30',
+                    'scope' => $namespace.'TestClass->coverage()',
+                ],
+            21 =>
+                [
+                    'type' => 'Arg30',
+                    'scope' => $namespace.'TestClass->coverage()',
+                ],
+            22 =>
+                [
+                    'type' => 'Expr_Closure30',
+                    'scope' => $namespace.'TestClass->coverage()',
+                ],
+            23 =>
+                [
+                    'type' => 'Stmt_Return31',
+                    'scope' => $namespace.'TestClass->coverage()::Closure',
+                ],
+            24 =>
+                [
+                    'type' => 'Scalar_String31',
+                    'scope' => $namespace.'TestClass->coverage()::Closure',
+                ],
+            25 =>
+                [
+                    'type' => 'Stmt_ClassMethod35',
+                    'scope' => $namespace.'TestClass',
+                ],
+            26 =>
+                [
+                    'type' => 'Stmt_Return37',
+                    'scope' => $namespace.'TestClass->vw()',
+                ],
+            27 =>
+                [
+                    'type' => 'Scalar_String37',
+                    'scope' => $namespace.'TestClass->vw()',
+                ],
+            28 =>
+                [
+                    'type' => 'Stmt_Class41',
+                    'scope' => $namespace,
+                ],
+        ];
+    }
+
+    const CODE = <<<'NEWDOC'
+use Exception;
+
+$x = "PHP rocks!";
+
+function test()
+{
+    return function () {
+        return "Hello, world!";
+    };
+}
+
+function nested()
+{
+    return function () {
+        return function () {
+            return function () {
+                return "Nested nested nested...";
+            };
+        };
+    };
+}
+
+class TestClass
+{
+    public function coverage()
+    {
+        return call_user_func(function () {
+            return "Coverage is 101%!";
+        });
+    }
+
+    public function vw()
+    {
+        return "OK (488 tests, 1134 assertions)";
+    }
+}
+
+class TestException extends Exception {}
+NEWDOC;
+
+    /**
+     * @param Node[] $nodes
+     *
+     * @return array
+     */
+    public function parseScopesRecursive(array $nodes)
+    {
+        $output = [];
+
+        foreach($nodes as $node)
+        {
+            $output[] = [
+                "type" => $node->getType().$node->getLine(),
+                "scope" => $node->getAttribute("scope")
+            ];
+
+            if($node instanceof Stmt\Function_
+                or $node instanceof Expr\Closure)
+            {
+                $output = array_merge($output, $this->parseScopesRecursive($node->getStmts()));
+            }
+            elseif($node instanceof Stmt\Use_ and isset($node->uses))
+            {
+                $output = array_merge($output, $this->parseScopesRecursive($node->uses));
+            }
+            elseif($node instanceof Stmt\Return_)
+            {
+                $output = array_merge($output, $this->parseScopesRecursive([$node->expr]));
+            }
+            elseif($node instanceof Stmt\Class_
+                or $node instanceof Stmt\ClassMethod)
+            {
+                $output = array_merge($output, $this->parseScopesRecursive($node->stmts));
+            }
+            elseif($node instanceof Expr\FuncCall)
+            {
+                $output = array_merge($output, $this->parseScopesRecursive($node->args));
+            }
+            elseif($node instanceof Node\Arg)
+            {
+                $output = array_merge($output, $this->parseScopesRecursive([$node->value]));
+            }
+        }
+
+        return $output;
+    }
+}


### PR DESCRIPTION
@nikic 
@ockham 

I've re-implemented #148 with proper differentiation between functions, classes, and Closures, along with corresponding docs and tests.

## Scopes

Root namespace: `\`
Function `test()` inside the root namespace: `\test()`
Raw `Vendor\Package\Tester` namespace: `\Vendor\Package\Tester\`
Function `test()` inside the namespace: `\Vendor\Package\Tester\test()`
Class `TestClass` inside the namespace `\Vendor\Package\Tester\TestClass`
Class method `coverage()`: `\Vendor\Package\Tester\TestClass->coverage()`
A Closure inside the root namespace: `\Closure`
Nested Closures inside the root namespace: `\Closure::Closure::Closure`
A Closure inside namespaced function `test()`: `\Vendor\Package\Tester\test()::Closure::Closure`
A Closure inside namespaced class method `coverage()`: `\Vendor\Package\Tester\TestClass->coverage()::Closure`