### PR TITLE
Better Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ language: php
 
 sudo: false
 
+cache:
+  directories:
+    - $HOME/.composer/cache
+
 php:
   - 5.4
   - 5.5
@@ -12,7 +16,7 @@ php:
 
 install:
   - if [ $TRAVIS_PHP_VERSION = '5.6' ]; then composer require satooshi/php-coveralls '~1.0'; fi
-  - composer install --prefer-source
+  - composer install --prefer-dist
 
 matrix:
   allow_failures:
@@ -24,3 +28,4 @@ script:
 
 after_success:
   if [ $TRAVIS_PHP_VERSION = '5.6' ]; then php vendor/bin/coveralls; fi
+


### PR DESCRIPTION
* Enable Travis cache for Composer
* Update composer before install to keep it up to date
* Authenticate Composer against GitHub to avoid hitting the API limit rate: **requires to add a Travis environment variable `GITHUB_OAUTH_TOKEN` with the token value. The token can be generated in your account panel and all boxes should be unchecked for the permissions right (i.e. do not giving it any permission - only use for authentication)
* Use `--prefer-dist` over `--prefer-source` to download less and make it faster