### PR TITLE
PrettyPrinter:Unnecessary escape in single quoted.

### DIFF
--- a/lib/PhpParser/PrettyPrinter/Standard.php
+++ b/lib/PhpParser/PrettyPrinter/Standard.php
@@ -98,7 +98,7 @@ class Standard extends PrettyPrinterAbstract
                 }
                 /* break missing intentionally */
             case Scalar\String_::KIND_SINGLE_QUOTED:
-                return '\'' . $this->pNoIndent(addcslashes($node->value, '\'')) . '\'';
+                return '\'' . $this->pNoIndent(addcslashes($node->value, '\'\\')) . '\'';
             case Scalar\String_::KIND_HEREDOC:
                 $label = $node->getAttribute('docLabel');
                 if ($label && !$this->containsEndLabel($node->value, $label)) {

--- a/lib/PhpParser/PrettyPrinter/Standard.php
+++ b/lib/PhpParser/PrettyPrinter/Standard.php
@@ -98,7 +98,7 @@ class Standard extends PrettyPrinterAbstract
                 }
                 /* break missing intentionally */
             case Scalar\String_::KIND_SINGLE_QUOTED:
-                return '\'' . $this->pNoIndent(addcslashes($node->value, '\'\\')) . '\'';
+                return '\'' . $this->pNoIndent(addcslashes($node->value, '\'')) . '\'';
             case Scalar\String_::KIND_HEREDOC:
                 $label = $node->getAttribute('docLabel');
                 if ($label && !$this->containsEndLabel($node->value, $label)) {

--- a/lib/PhpParser/PrettyPrinter/Standard.php
+++ b/lib/PhpParser/PrettyPrinter/Standard.php
@@ -850,7 +850,7 @@ class Standard extends PrettyPrinterAbstract
             // For doc strings, don't escape newlines
             return addcslashes($string, "\t\f\v$\\");
         }
-        return addcslashes($string, "\n\r\t\f\v$" . $quote . "\\");
+        return str_replace("\0", '\0', addcslashes($string, "\n\r\t\f\v$" . $quote . "\\"));
     }
 
     protected function containsEndLabel($string, $label, $atStart = true, $atEnd = true) {

--- a/lib/PhpParser/PrettyPrinter/Standard.php
+++ b/lib/PhpParser/PrettyPrinter/Standard.php
@@ -850,7 +850,11 @@ class Standard extends PrettyPrinterAbstract
             // For doc strings, don't escape newlines
             return addcslashes($string, "\t\f\v$\\");
         }
-        return str_replace("\0", '\0', addcslashes($string, "\n\r\t\f\v$" . $quote . "\\"));
+        return preg_replace(
+            array('/\\0(?![0-7])/', '/\\0/'),
+            array('\\\\0', '\\\\000'),
+            addcslashes($string, "\n\r\t\f\v$" . $quote . "\\")
+        );
     }
 
     protected function containsEndLabel($string, $label, $atStart = true, $atEnd = true) {


### PR DESCRIPTION
```
>php-parse --pretty-print "<?php echo 'path\to';
====> Code <?php echo 'path\to';
==> Pretty print:
<?php

echo 'path\\to';
```