### PR TITLE
make autoloader more PSR-4

### DIFF
--- a/lib/PhpParser/Autoloader.php
+++ b/lib/PhpParser/Autoloader.php
@@ -31,7 +31,7 @@ class Autoloader
      */
     static public function autoload($class) {
         if (0 === strpos($class, 'PhpParser\\')) {
-            $fileName = dirname(__DIR__) . '/' . strtr($class, '\\', '/') . '.php';
+            $fileName = __DIR__ . strtr(substr($class, 9), '\\', '/') . '.php';
             if (file_exists($fileName)) {
                 require $fileName;
             }


### PR DESCRIPTION
Minor change to avoid relying on dirname(__DIR__) == PhpParser

This is useful for downstream distribution where we'd like to provides both v1.x and v2.x installed in a different tree