### PR TITLE
Remove new-line after PHP closing tag

### DIFF
--- a/lib/PhpParser/PrettyPrinter/Standard.php
+++ b/lib/PhpParser/PrettyPrinter/Standard.php
@@ -791,7 +791,7 @@ class Standard extends PrettyPrinterAbstract
     }
 
     public function pStmt_InlineHTML(Stmt\InlineHTML $node) {
-        return '?>' . $this->pNoIndent("\n" . $node->value) . '<?php ';
+        return '?>' . $this->pNoIndent($node->value) . '<?php ';
     }
 
     public function pStmt_HaltCompiler(Stmt\HaltCompiler $node) {


### PR DESCRIPTION
There shouldn't have to be a forced new-line after a closing PHP tag.
The non-PHP code still contains all new-lines it had so adding additional stuff would break original formatting.

Fixes https://github.com/nikic/PHP-Parser/issues/280