### PR TITLE
Run on Trusty Beta Container

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: php
-
+dist: trusty
 sudo: false
 
 cache:
@@ -16,6 +16,8 @@ php:
 install:
   - if [ $TRAVIS_PHP_VERSION = '5.6' ]; then composer require satooshi/php-coveralls '~1.0'; fi
   - composer install --prefer-dist
+  # Disable JIT compilation in hhvm, as the JIT is useless for short live scripts like tests.
+  - if [[ $TRAVIS_PHP_VERSION = hhvm* ]]; then echo 'hhvm.jit = 0' >> /etc/hhvm/php.ini; fi
 
 matrix:
   allow_failures:
@@ -29,4 +31,3 @@ script:
 
 after_success:
   if [ $TRAVIS_PHP_VERSION = '5.6' ]; then php vendor/bin/coveralls; fi
-


### PR DESCRIPTION
Runs the tests on the newer Trusty containers since this repo is not affected by the mysql issues in the trusty container. 

Added benefit, This provides the current HHVM version (3.18.1 as of this PR) and will track with each release (i.e. will be 3.19 when 3.19 is released). ... **you are currently on an EOL versions of HHVM since precise was dropped back at hhvm 3.6**

If testing against HHVM LST versions is desired follow this guide. https://docs.travis-ci.com/user/languages/php#HHVM-versions

NOTE: If testing against HHVM in php 7 mode is desired: HHVM php 7 mode currently has an issue that messes up composer under php 7 mode, see facebook/hhvm#7198 once that BUG is fixed HHVM PHP 7 mode testing could be added