### PR TITLE
Make the Error class used explicit.

### DIFF
--- a/lib/PhpParser/ErrorHandler.php
+++ b/lib/PhpParser/ErrorHandler.php
@@ -2,6 +2,8 @@
 
 namespace PhpParser;
 
+use PhpParser\Error;
+
 interface ErrorHandler
 {
     /**


### PR DESCRIPTION
Saw the below error in php 7.1 (The base class didn't have a `use`, but the subclass did). Not fully familiar with the rules for checking if unqualified names were compatible, but this fixes it.

Seen in 3.0.5

```
Fatal error: Uncaught Error: Declaration of PhpParser\ErrorHandler\Throwing::handleError() must be compatible with that of PhpParser\ErrorHandler::handleError() in .../vendor/nikic/php-parser/lib/PhpParser/ErrorHandler/
Throwing.php:13
Stack trace:
\#0 .../vendor/nikic/php-parser/lib/PhpParser/Autoloader.php(36): include()
\#1 ..../vendor/nikic/php-parser/lib/PhpParser/ParserAbstract.php(144): PhpParser\Autoloader::autoload()
...
```