### PR TITLE
Removes unneeded code from JSON encoding example.

### DIFF
--- a/doc/3_Other_node_tree_representations.markdown
+++ b/doc/3_Other_node_tree_representations.markdown
@@ -104,7 +104,6 @@ printLine('Hello World!!!');
 CODE;
 
 $parser = (new PhpParser\ParserFactory)->create(PhpParser\ParserFactory::PREFER_PHP7);
-$nodeDumper = new PhpParser\NodeDumper;
 
 try {
     $stmts = $parser->parse($code);


### PR DESCRIPTION
Unless I am mistaken the NodeDumper is _not_ needed when outputting to JSOn, so the following line  can be removed from the docs:
```php
$nodeDumper = new PhpParser\NodeDumper;
```