### PR TITLE
Move token byref vars into object

### DIFF
--- a/lib/PhpParser/Lexer.php
+++ b/lib/PhpParser/Lexer.php
@@ -223,15 +223,11 @@ class Lexer
      *  * 'startFilePos'  => Offset into the code string of the first character that is part of the node.
      *  * 'endFilePos'    => Offset into the code string of the last character that is part of the node.
      *
-     * @param mixed $value           Variable to store token content in
-     * @param mixed $startAttributes Variable to store start attributes in
-     * @param mixed $endAttributes   Variable to store end attributes in
-     *
-     * @return int Token id
+     * @return Lexer\TokenContainer
      */
-    public function getNextToken(&$value = null, &$startAttributes = null, &$endAttributes = null) {
-        $startAttributes = array();
-        $endAttributes   = array();
+    public function getNextToken() {
+        $startAttributes = [];
+        $endAttributes = [];
 
         while (1) {
             if (isset($this->tokens[++$this->pos])) {
@@ -297,7 +293,13 @@ class Lexer
                 $endAttributes['endFilePos'] = $this->filePos - 1;
             }
 
-            return $id;
+            $tokenContainer = new Lexer\TokenContainer();
+            $tokenContainer->id = $id;
+            $tokenContainer->startAttributes = $startAttributes;
+            $tokenContainer->endAttributes = $endAttributes;
+            $tokenContainer->value = $value;
+
+            return $tokenContainer;
         }
 
         throw new \RuntimeException('Reached end of lexer loop');

--- a/lib/PhpParser/Lexer/TokenContainer.php
+++ b/lib/PhpParser/Lexer/TokenContainer.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace PhpParser\Lexer;
+
+class TokenContainer
+{
+    /**
+     * Token Id
+     *
+     * @var int
+     */
+    public $id;
+
+    /**
+     * Variable to store token content in
+     *
+     * @var string
+     */
+    public $value;
+
+    /**
+     * Variable to store start attributes in
+     *
+     * @var array
+     */
+    public $startAttributes = [];
+
+    /**
+     * Variable to store end attributes in
+     *
+     * @var array
+     */
+    public $endAttributes = [];
+}

--- a/lib/PhpParser/ParserAbstract.php
+++ b/lib/PhpParser/ParserAbstract.php
@@ -199,7 +199,12 @@ abstract class ParserAbstract implements Parser
                     // The end attributes are fetched into a temporary variable and only set once the token is really
                     // shifted (not during read). Otherwise you would sometimes get off-by-one errors, when a rule is
                     // reduced after a token was read but not yet shifted.
-                    $tokenId = $this->lexer->getNextToken($tokenValue, $startAttributes, $endAttributes);
+                    $tokenContainer = $this->lexer->getNextToken();
+
+                    $tokenId = $tokenContainer->id;
+                    $tokenValue = $tokenContainer->value;
+                    $startAttributes = $tokenContainer->startAttributes;
+                    $endAttributes = $tokenContainer->endAttributes;
 
                     // map the lexer token id to the internally used symbols
                     $symbol = $tokenId >= 0 && $tokenId < $this->tokenToSymbolMapSize

--- a/test/PhpParser/Lexer/EmulativeTest.php
+++ b/test/PhpParser/Lexer/EmulativeTest.php
@@ -20,8 +20,10 @@ class EmulativeTest extends LexerTest
         $lexer = $this->getLexer();
         $lexer->startLexing('<?php ' . $keyword);
 
-        $this->assertSame($expectedToken, $lexer->getNextToken());
-        $this->assertSame(0, $lexer->getNextToken());
+        $tokenContainer = $lexer->getNextToken();
+        $this->assertSame($expectedToken, $tokenContainer->id);
+        $tokenContainer = $lexer->getNextToken();
+        $this->assertSame(0, $tokenContainer->id);
     }
 
     /**
@@ -31,9 +33,12 @@ class EmulativeTest extends LexerTest
         $lexer = $this->getLexer();
         $lexer->startLexing('<?php ->' . $keyword);
 
-        $this->assertSame(Tokens::T_OBJECT_OPERATOR, $lexer->getNextToken());
-        $this->assertSame(Tokens::T_STRING, $lexer->getNextToken());
-        $this->assertSame(0, $lexer->getNextToken());
+        $tokenContainer = $lexer->getNextToken();
+        $this->assertSame(Tokens::T_OBJECT_OPERATOR, $tokenContainer->id);
+        $tokenContainer = $lexer->getNextToken();
+        $this->assertSame(Tokens::T_STRING, $tokenContainer->id);
+        $tokenContainer = $lexer->getNextToken();
+        $this->assertSame(0, $tokenContainer->id);
     }
 
     public function provideTestReplaceKeywords() {
@@ -65,10 +70,13 @@ class EmulativeTest extends LexerTest
 
         foreach ($expectedTokens as $expectedToken) {
             list($expectedTokenType, $expectedTokenText) = $expectedToken;
-            $this->assertSame($expectedTokenType, $lexer->getNextToken($text));
-            $this->assertSame($expectedTokenText, $text);
+            $tokenContainer = $lexer->getNextToken();
+            $this->assertSame($expectedTokenType, $tokenContainer->id);
+            $this->assertSame($expectedTokenText, $tokenContainer->value);
         }
-        $this->assertSame(0, $lexer->getNextToken());
+
+        $tokenContainer = $lexer->getNextToken();
+        $this->assertSame(0, $tokenContainer->id);
     }
 
     /**
@@ -80,9 +88,12 @@ class EmulativeTest extends LexerTest
         $lexer = $this->getLexer();
         $lexer->startLexing('<?php ' . $stringifiedToken);
 
-        $this->assertSame(Tokens::T_CONSTANT_ENCAPSED_STRING, $lexer->getNextToken($text));
-        $this->assertSame($stringifiedToken, $text);
-        $this->assertSame(0, $lexer->getNextToken());
+        $tokenContainer = $lexer->getNextToken();
+        $this->assertSame(Tokens::T_CONSTANT_ENCAPSED_STRING, $tokenContainer->id);
+        $this->assertSame($stringifiedToken, $tokenContainer->value);
+
+        $tokenContainer = $lexer->getNextToken();
+        $this->assertSame(0, $tokenContainer->id);
     }
 
     public function provideTestLexNewFeatures() {

--- a/test/PhpParser/LexerTest.php
+++ b/test/PhpParser/LexerTest.php
@@ -56,7 +56,7 @@ class LexerTest extends \PHPUnit_Framework_TestCase
 
         $value = null;
         
-        do {
+        while (1) {
             $tokenContainer = $lexer->getNextToken($value);
 
             if (!$tokenContainer->id) {
@@ -69,7 +69,7 @@ class LexerTest extends \PHPUnit_Framework_TestCase
             $this->assertSame($token[1], $tokenContainer->value);
             $this->assertEquals($token[2], $tokenContainer->startAttributes);
             $this->assertEquals($token[3], $tokenContainer->endAttributes);
-        } while ($tokenContainer->id);
+        }
     }
 
     public function provideTestLex() {

--- a/test/PhpParser/ParserTest.php
+++ b/test/PhpParser/ParserTest.php
@@ -175,8 +175,10 @@ EOC;
 }
 
 class InvalidTokenLexer extends Lexer {
-    public function getNextToken(&$value = null, &$startAttributes = null, &$endAttributes = null) {
-        $value = 'foobar';
-        return 999;
+    public function getNextToken() {
+        $tokenContainer = new \PhpParser\Lexer\TokenContainer();
+        $tokenContainer->value = 'foobar';
+        $tokenContainer->id = 999;
+        return $tokenContainer;
     }
 }


### PR DESCRIPTION
This removes the only byref function params in the lexer. This doesn't fix any bugs – just makes the code a little easier to reason about.

Feel free not to merge if you think there are performance implications. But I didn't see a negative impact in my own testing, FWIW.