### PR TITLE
Bump PHPUnit version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "ext-tokenizer": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "~5.0"
+        "phpunit/phpunit": "^6"
     },
     "autoload": {
         "psr-4": {

--- a/test/PhpParser/AutoloaderTest.php
+++ b/test/PhpParser/AutoloaderTest.php
@@ -4,7 +4,10 @@ namespace PhpParser;
 
 /* The autoloader is already active at this point, so we only check effects here. */
 
-class AutoloaderTest extends \PHPUnit_Framework_TestCase {
+use PHPUnit\Framework\TestCase;
+
+class AutoloaderTest extends TestCase
+{
     public function testClassExists() {
         $this->assertTrue(class_exists('PhpParser\NodeVisitorAbstract'));
         $this->assertFalse(class_exists('PHPParser_NodeVisitor_NameResolver'));

--- a/test/PhpParser/Builder/ClassTest.php
+++ b/test/PhpParser/Builder/ClassTest.php
@@ -6,8 +6,9 @@ use PhpParser\Comment;
 use PhpParser\Node;
 use PhpParser\Node\Name;
 use PhpParser\Node\Stmt;
+use PHPUnit\Framework\TestCase;
 
-class ClassTest extends \PHPUnit_Framework_TestCase
+class ClassTest extends TestCase
 {
     protected function createClassBuilder($class) {
         return new Class_($class);

--- a/test/PhpParser/Builder/FunctionTest.php
+++ b/test/PhpParser/Builder/FunctionTest.php
@@ -8,8 +8,9 @@ use PhpParser\Node\Expr\Print_;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Scalar\String_;
 use PhpParser\Node\Stmt;
+use PHPUnit\Framework\TestCase;
 
-class FunctionTest extends \PHPUnit_Framework_TestCase
+class FunctionTest extends TestCase
 {
     public function createFunctionBuilder($name) {
         return new Function_($name);

--- a/test/PhpParser/Builder/InterfaceTest.php
+++ b/test/PhpParser/Builder/InterfaceTest.php
@@ -6,8 +6,9 @@ use PhpParser\Comment;
 use PhpParser\Node;
 use PhpParser\Node\Scalar\DNumber;
 use PhpParser\Node\Stmt;
+use PHPUnit\Framework\TestCase;
 
-class InterfaceTest extends \PHPUnit_Framework_TestCase
+class InterfaceTest extends TestCase
 {
     /** @var Interface_ */
     protected $builder;

--- a/test/PhpParser/Builder/MethodTest.php
+++ b/test/PhpParser/Builder/MethodTest.php
@@ -8,8 +8,9 @@ use PhpParser\Node\Expr\Print_;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Scalar\String_;
 use PhpParser\Node\Stmt;
+use PHPUnit\Framework\TestCase;
 
-class MethodTest extends \PHPUnit_Framework_TestCase
+class MethodTest extends TestCase
 {
     public function createMethodBuilder($name) {
         return new Method($name);

--- a/test/PhpParser/Builder/NamespaceTest.php
+++ b/test/PhpParser/Builder/NamespaceTest.php
@@ -4,8 +4,9 @@ namespace PhpParser\Builder;
 
 use PhpParser\Node;
 use PhpParser\Node\Stmt;
+use PHPUnit\Framework\TestCase;
 
-class NamespaceTest extends \PHPUnit_Framework_TestCase
+class NamespaceTest extends TestCase
 {
     protected function createNamespaceBuilder($fqn) {
         return new Namespace_($fqn);

--- a/test/PhpParser/Builder/ParamTest.php
+++ b/test/PhpParser/Builder/ParamTest.php
@@ -5,8 +5,9 @@ namespace PhpParser\Builder;
 use PhpParser\Node;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Scalar;
+use PHPUnit\Framework\TestCase;
 
-class ParamTest extends \PHPUnit_Framework_TestCase
+class ParamTest extends TestCase
 {
     public function createParamBuilder($name) {
         return new Param($name);

--- a/test/PhpParser/Builder/PropertyTest.php
+++ b/test/PhpParser/Builder/PropertyTest.php
@@ -7,8 +7,9 @@ use PhpParser\Node\Expr;
 use PhpParser\Node\Name;
 use PhpParser\Node\Scalar;
 use PhpParser\Node\Stmt;
+use PHPUnit\Framework\TestCase;
 
-class PropertyTest extends \PHPUnit_Framework_TestCase
+class PropertyTest extends TestCase
 {
     public function createPropertyBuilder($name) {
         return new Property($name);

--- a/test/PhpParser/Builder/TraitTest.php
+++ b/test/PhpParser/Builder/TraitTest.php
@@ -4,8 +4,9 @@ namespace PhpParser\Builder;
 
 use PhpParser\Comment;
 use PhpParser\Node\Stmt;
+use PHPUnit\Framework\TestCase;
 
-class TraitTest extends \PHPUnit_Framework_TestCase
+class TraitTest extends TestCase
 {
     protected function createTraitBuilder($class) {
         return new Trait_($class);

--- a/test/PhpParser/Builder/UseTest.php
+++ b/test/PhpParser/Builder/UseTest.php
@@ -3,8 +3,9 @@
 use PhpParser\Builder;
 use PhpParser\Node\Name;
 use PhpParser\Node\Stmt;
+use PHPUnit\Framework\TestCase;
 
-class UseTest extends \PHPUnit_Framework_TestCase
+class UseTest extends TestCase
 {
     protected function createUseBuilder($name, $type = Stmt\Use_::TYPE_NORMAL) {
         return new Builder\Use_($name, $type);
@@ -28,7 +29,8 @@ class UseTest extends \PHPUnit_Framework_TestCase
     }
 
     public function testNonExistingMethod() {
-        $this->setExpectedException('LogicException', 'Method "foo" does not exist');
+        $this->expectException('LogicException');
+        $this->expectExceptionMessage('Method "foo" does not exist');
         $builder = $this->createUseBuilder('Test');
         $builder->foo();
     }

--- a/test/PhpParser/BuilderFactoryTest.php
+++ b/test/PhpParser/BuilderFactoryTest.php
@@ -5,8 +5,9 @@ namespace PhpParser;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\BinaryOp\Concat;
 use PhpParser\Node\Scalar\String_;
+use PHPUnit\Framework\TestCase;
 
-class BuilderFactoryTest extends \PHPUnit_Framework_TestCase
+class BuilderFactoryTest extends TestCase
 {
     /**
      * @dataProvider provideTestFactory
@@ -31,7 +32,8 @@ class BuilderFactoryTest extends \PHPUnit_Framework_TestCase
     }
 
     public function testNonExistingMethod() {
-        $this->setExpectedException('LogicException', 'Method "foo" does not exist');
+        $this->expectException('LogicException');
+        $this->expectExceptionMessage('Method "foo" does not exist');
         $factory = new BuilderFactory();
         $factory->foo();
     }

--- a/test/PhpParser/CodeTestAbstract.php
+++ b/test/PhpParser/CodeTestAbstract.php
@@ -2,9 +2,11 @@
 
 namespace PhpParser;
 
+use PHPUnit\Framework\TestCase;
+
 require_once __DIR__ . '/CodeTestParser.php';
 
-abstract class CodeTestAbstract extends \PHPUnit_Framework_TestCase
+abstract class CodeTestAbstract extends TestCase
 {
     protected function getTests($directory, $fileExtension, $chunksPerTest = 2) {
         $parser = new CodeTestParser;

--- a/test/PhpParser/CommentTest.php
+++ b/test/PhpParser/CommentTest.php
@@ -2,7 +2,9 @@
 
 namespace PhpParser;
 
-class CommentTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class CommentTest extends TestCase
 {
     public function testGetSet() {
         $comment = new Comment('/* Some comment */', 1, 10);

--- a/test/PhpParser/ErrorHandler/CollectingTest.php
+++ b/test/PhpParser/ErrorHandler/CollectingTest.php
@@ -3,8 +3,10 @@
 namespace PhpParser\ErrorHandler;
 
 use PhpParser\Error;
+use PHPUnit\Framework\TestCase;
 
-class CollectingTest extends \PHPUnit_Framework_TestCase {
+class CollectingTest extends TestCase
+{
     public function testHandleError() {
         $errorHandler = new Collecting();
         $this->assertFalse($errorHandler->hasErrors());

--- a/test/PhpParser/ErrorHandler/ThrowingTest.php
+++ b/test/PhpParser/ErrorHandler/ThrowingTest.php
@@ -3,8 +3,10 @@
 namespace PhpParser\ErrorHandler;
 
 use PhpParser\Error;
+use PHPUnit\Framework\TestCase;
 
-class ThrowingTest extends \PHPUnit_Framework_TestCase {
+class ThrowingTest extends TestCase
+{
     /**
      * @expectedException \PhpParser\Error
      * @expectedExceptionMessage Test

--- a/test/PhpParser/ErrorTest.php
+++ b/test/PhpParser/ErrorTest.php
@@ -2,7 +2,9 @@
 
 namespace PhpParser;
 
-class ErrorTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class ErrorTest extends TestCase
 {
     public function testConstruct() {
         $attributes = array(

--- a/test/PhpParser/LexerTest.php
+++ b/test/PhpParser/LexerTest.php
@@ -3,8 +3,9 @@
 namespace PhpParser;
 
 use PhpParser\Parser\Tokens;
+use PHPUnit\Framework\TestCase;
 
-class LexerTest extends \PHPUnit_Framework_TestCase
+class LexerTest extends TestCase
 {
     /* To allow overwriting in parent class */
     protected function getLexer(array $options = array()) {

--- a/test/PhpParser/Node/NameTest.php
+++ b/test/PhpParser/Node/NameTest.php
@@ -2,7 +2,9 @@
 
 namespace PhpParser\Node;
 
-class NameTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class NameTest extends TestCase
 {
     public function testConstruct() {
         $name = new Name(array('foo', 'bar'));

--- a/test/PhpParser/Node/Scalar/MagicConstTest.php
+++ b/test/PhpParser/Node/Scalar/MagicConstTest.php
@@ -2,7 +2,10 @@
 
 namespace PhpParser\Node\Scalar;
 
-class MagicConstTest extends \PHPUnit_Framework_TestCase {
+use PHPUnit\Framework\TestCase;
+
+class MagicConstTest extends TestCase
+{
     /**
      * @dataProvider provideTestGetName
      */

--- a/test/PhpParser/Node/Scalar/StringTest.php
+++ b/test/PhpParser/Node/Scalar/StringTest.php
@@ -2,7 +2,9 @@
 
 namespace PhpParser\Node\Scalar;
 
-class StringTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class StringTest extends TestCase
 {
     /**
      * @dataProvider provideTestParseEscapeSequences

--- a/test/PhpParser/Node/Stmt/ClassConstTest.php
+++ b/test/PhpParser/Node/Stmt/ClassConstTest.php
@@ -2,7 +2,9 @@
 
 namespace PhpParser\Node\Stmt;
 
-class ClassConstTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class ClassConstTest extends TestCase
 {
     /**
      * @dataProvider provideModifiers

--- a/test/PhpParser/Node/Stmt/ClassMethodTest.php
+++ b/test/PhpParser/Node/Stmt/ClassMethodTest.php
@@ -2,7 +2,9 @@
 
 namespace PhpParser\Node\Stmt;
 
-class ClassMethodTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class ClassMethodTest extends TestCase
 {
     /**
      * @dataProvider provideModifiers

--- a/test/PhpParser/Node/Stmt/ClassTest.php
+++ b/test/PhpParser/Node/Stmt/ClassTest.php
@@ -2,7 +2,9 @@
 
 namespace PhpParser\Node\Stmt;
 
-class ClassTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class ClassTest extends TestCase
 {
     public function testIsAbstract() {
         $class = new Class_('Foo', array('type' => Class_::MODIFIER_ABSTRACT));

--- a/test/PhpParser/Node/Stmt/InterfaceTest.php
+++ b/test/PhpParser/Node/Stmt/InterfaceTest.php
@@ -3,8 +3,9 @@
 namespace PhpParser\Node\Stmt;
 
 use PhpParser\Node;
+use PHPUnit\Framework\TestCase;
 
-class InterfaceTest extends \PHPUnit_Framework_TestCase
+class InterfaceTest extends TestCase
 {
     public function testGetMethods() {
         $methods = array(

--- a/test/PhpParser/Node/Stmt/PropertyTest.php
+++ b/test/PhpParser/Node/Stmt/PropertyTest.php
@@ -2,7 +2,9 @@
 
 namespace PhpParser\Node\Stmt;
 
-class PropertyTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class PropertyTest extends TestCase
 {
     /**
      * @dataProvider provideModifiers

--- a/test/PhpParser/NodeAbstractTest.php
+++ b/test/PhpParser/NodeAbstractTest.php
@@ -2,6 +2,8 @@
 
 namespace PhpParser;
 
+use PHPUnit\Framework\TestCase;
+
 class DummyNode extends NodeAbstract {
     public $subNode1;
     public $subNode2;
@@ -22,7 +24,7 @@ class DummyNode extends NodeAbstract {
     }
 }
 
-class NodeAbstractTest extends \PHPUnit_Framework_TestCase
+class NodeAbstractTest extends TestCase
 {
     public function provideNodes() {
         $attributes = array(

--- a/test/PhpParser/NodeDumperTest.php
+++ b/test/PhpParser/NodeDumperTest.php
@@ -2,7 +2,9 @@
 
 namespace PhpParser;
 
-class NodeDumperTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class NodeDumperTest extends TestCase
 {
     private function canonicalize($string) {
         return str_replace("\r\n", "\n", $string);

--- a/test/PhpParser/NodeFinderTest.php
+++ b/test/PhpParser/NodeFinderTest.php
@@ -3,8 +3,10 @@
 namespace PhpParser;
 
 use PhpParser\Node\Expr;
+use PHPUnit\Framework\TestCase;
 
-class NodeFinderTest extends \PHPUnit_Framework_TestCase {
+class NodeFinderTest extends TestCase
+{
     private function getStmtsAndVars() {
         $assign = new Expr\Assign(new Expr\Variable('a'), new Expr\BinaryOp\Concat(
             new Expr\Variable('b'), new Expr\Variable('c')

--- a/test/PhpParser/NodeTraverserTest.php
+++ b/test/PhpParser/NodeTraverserTest.php
@@ -4,8 +4,9 @@ namespace PhpParser;
 
 use PhpParser\Node\Expr;
 use PhpParser\Node\Scalar\String_;
+use PHPUnit\Framework\TestCase;
 
-class NodeTraverserTest extends \PHPUnit_Framework_TestCase
+class NodeTraverserTest extends TestCase
 {
     public function testNonModifying() {
         $str1Node = new String_('Foo');
@@ -253,7 +254,8 @@ class NodeTraverserTest extends \PHPUnit_Framework_TestCase
      * @dataProvider provideTestInvalidReturn
      */
     public function testInvalidReturn($visitor, $message) {
-        $this->setExpectedException(\LogicException::class, $message);
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage($message);
 
         $stmts = array(new Node\Expr\UnaryMinus(new Node\Scalar\LNumber(42)));
 

--- a/test/PhpParser/NodeVisitor/FindingVisitorTest.php
+++ b/test/PhpParser/NodeVisitor/FindingVisitorTest.php
@@ -5,8 +5,10 @@ namespace PhpParser\NodeVisitor;
 use PhpParser\Node;
 use PhpParser\Node\Expr;
 use PhpParser\NodeTraverser;
+use PHPUnit\Framework\TestCase;
 
-class FindingVisitorTest extends \PHPUnit_Framework_TestCase {
+class FindingVisitorTest extends TestCase
+{
     public function testFindVariables() {
         $traverser = new NodeTraverser();
         $visitor = new FindingVisitor(function(Node $node) {

--- a/test/PhpParser/NodeVisitor/FirstFindingVisitorTest.php
+++ b/test/PhpParser/NodeVisitor/FirstFindingVisitorTest.php
@@ -5,8 +5,9 @@ namespace PhpParser\NodeVisitor;
 use PhpParser\Node;
 use PhpParser\Node\Expr;
 use PhpParser\NodeTraverser;
+use PHPUnit\Framework\TestCase;
 
-class FirstFindingVisitorTest extends \PHPUnit_Framework_TestCase
+class FirstFindingVisitorTest extends TestCase
 {
     public function testFindFirstVariable() {
         $traverser = new NodeTraverser();

--- a/test/PhpParser/NodeVisitor/NameResolverTest.php
+++ b/test/PhpParser/NodeVisitor/NameResolverTest.php
@@ -7,8 +7,9 @@ use PhpParser\Node;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Name;
 use PhpParser\Node\Stmt;
+use PHPUnit\Framework\TestCase;
 
-class NameResolverTest extends \PHPUnit_Framework_TestCase
+class NameResolverTest extends TestCase
 {
     private function canonicalize($string) {
         return str_replace("\r\n", "\n", $string);
@@ -346,7 +347,8 @@ EOC;
      * @dataProvider provideTestError
      */
     public function testError(Node $stmt, $errorMsg) {
-        $this->setExpectedException('PhpParser\Error', $errorMsg);
+        $this->expectException('PhpParser\Error');
+        $this->expectExceptionMessage($errorMsg);
 
         $traverser = new PhpParser\NodeTraverser;
         $traverser->addVisitor(new NameResolver);

--- a/test/PhpParser/Parser/MultipleTest.php
+++ b/test/PhpParser/Parser/MultipleTest.php
@@ -78,7 +78,8 @@ class MultipleTest extends ParserTest {
     }
 
     public function testThrownError() {
-        $this->setExpectedException('PhpParser\Error', 'FAIL A');
+        $this->expectException('PhpParser\Error');
+        $this->expectExceptionMessage('FAIL A');
 
         $parserA = $this->getMockBuilder('PhpParser\Parser')->getMock();
         $parserA->expects($this->at(0))

--- a/test/PhpParser/ParserFactoryTest.php
+++ b/test/PhpParser/ParserFactoryTest.php
@@ -4,7 +4,10 @@ namespace PhpParser;
 
 /* This test is very weak, because PHPUnit's assertEquals assertion is way too slow dealing with the
  * large objects involved here. So we just do some basic instanceof tests instead. */
-class ParserFactoryTest extends \PHPUnit_Framework_TestCase {
+use PHPUnit\Framework\TestCase;
+
+class ParserFactoryTest extends TestCase
+{
     /** @dataProvider provideTestCreate */
     public function testCreate($kind, $lexer, $expected) {
         $this->assertInstanceOf($expected, (new ParserFactory)->create($kind, $lexer));

--- a/test/PhpParser/ParserTest.php
+++ b/test/PhpParser/ParserTest.php
@@ -6,8 +6,9 @@ use PhpParser\Comment;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Scalar;
 use PhpParser\Node\Scalar\String_;
+use PHPUnit\Framework\TestCase;
 
-abstract class ParserTest extends \PHPUnit_Framework_TestCase
+abstract class ParserTest extends TestCase
 {
     /** @returns Parser */
     abstract protected function getParser(Lexer $lexer);


### PR DESCRIPTION
Happened to do this when I was playing with something else, PR'd in case you may want to bump the version.

Also, there's a PHPUnit config option (beStrictAboutTestsThatDoNotTestAnything) that you could set to false to avoid the risky tests flood but I doubt that'd be the correct way to do so.