### PR TITLE
Fixed incorrect class inheritance in code generation example (docs)

### DIFF
--- a/doc/4_Code_generation.markdown
+++ b/doc/4_Code_generation.markdown
@@ -21,8 +21,8 @@ use PhpParser\Node;
 $factory = new BuilderFactory;
 $node = $factory->namespace('Name\Space')
     ->addStmt($factory->use('Some\Other\Thingy')->as('SomeOtherClass'))
-    ->addStmt($factory->class('SomeClass')
-        ->extend('SomeOtherClass')
+    ->addStmt($factory->class('SomeOtherClass')
+        ->extend('SomeClass')
         ->implement('A\Few', '\Interfaces')
         ->makeAbstract() // ->makeFinal()
 
@@ -66,7 +66,7 @@ This will produce the following output with the standard pretty printer:
 namespace Name\Space;
 
 use Some\Other\Thingy as SomeClass;
-abstract class SomeClass extends SomeOtherClass implements A\Few, \Interfaces
+abstract class SomeOtherClass extends SomeClass implements A\Few, \Interfaces
 {
     protected $someProperty;
     private $anotherProperty = array(1, 2, 3);


### PR DESCRIPTION
Generated example was incorrect - you cannot define import alias:
use Some\Other\Thingy as SomeClass;

and then define a class with the same name:
abstract class SomeClass ...

Class names changed to avoid conflict between import alias and abstract class name.