### PR TITLE
Add strict_types declarations 

### DIFF
--- a/bin/php-parse
+++ b/bin/php-parse
@@ -26,9 +26,9 @@ if (empty($files)) {
     showHelp("Must specify at least one file.");
 }
 
-$lexer = new PhpParser\Lexer\Emulative(array('usedAttributes' => array(
+$lexer = new PhpParser\Lexer\Emulative(['usedAttributes' => [
     'startLine', 'endLine', 'startFilePos', 'endFilePos', 'comments'
-)));
+]]);
 $parser = (new PhpParser\ParserFactory)->create(
     PhpParser\ParserFactory::PREFER_PHP7,
     $lexer
@@ -130,13 +130,13 @@ OUTPUT
 }
 
 function parseArgs($args) {
-    $operations = array();
-    $files = array();
-    $attributes = array(
+    $operations = [];
+    $files = [];
+    $attributes = [
         'with-column-info' => false,
         'with-positions' => false,
         'with-recovery' => false,
-    );
+    ];
 
     array_shift($args);
     $parseOptions = true;
@@ -193,5 +193,5 @@ function parseArgs($args) {
         }
     }
 
-    return array($operations, $files, $attributes);
+    return [$operations, $files, $attributes];
 }

--- a/lib/PhpParser/Autoloader.php
+++ b/lib/PhpParser/Autoloader.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser;
 
 /**

--- a/lib/PhpParser/Builder.php
+++ b/lib/PhpParser/Builder.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser;
 
 interface Builder

--- a/lib/PhpParser/Builder/Class_.php
+++ b/lib/PhpParser/Builder/Class_.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Builder;
 
 use PhpParser;

--- a/lib/PhpParser/Builder/Declaration.php
+++ b/lib/PhpParser/Builder/Declaration.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Builder;
 
 use PhpParser;

--- a/lib/PhpParser/Builder/FunctionLike.php
+++ b/lib/PhpParser/Builder/FunctionLike.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Builder;
 
 use PhpParser\BuilderHelpers;

--- a/lib/PhpParser/Builder/Function_.php
+++ b/lib/PhpParser/Builder/Function_.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Builder;
 
 use PhpParser;

--- a/lib/PhpParser/Builder/Interface_.php
+++ b/lib/PhpParser/Builder/Interface_.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Builder;
 
 use PhpParser;

--- a/lib/PhpParser/Builder/Method.php
+++ b/lib/PhpParser/Builder/Method.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Builder;
 
 use PhpParser;

--- a/lib/PhpParser/Builder/Namespace_.php
+++ b/lib/PhpParser/Builder/Namespace_.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Builder;
 
 use PhpParser;

--- a/lib/PhpParser/Builder/Param.php
+++ b/lib/PhpParser/Builder/Param.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Builder;
 
 use PhpParser;

--- a/lib/PhpParser/Builder/Property.php
+++ b/lib/PhpParser/Builder/Property.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Builder;
 
 use PhpParser;

--- a/lib/PhpParser/Builder/Trait_.php
+++ b/lib/PhpParser/Builder/Trait_.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Builder;
 
 use PhpParser;

--- a/lib/PhpParser/Builder/Use_.php
+++ b/lib/PhpParser/Builder/Use_.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Builder;
 
 use PhpParser\Builder;

--- a/lib/PhpParser/BuilderFactory.php
+++ b/lib/PhpParser/BuilderFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser;
 
 use PhpParser\Node\Arg;

--- a/lib/PhpParser/BuilderHelpers.php
+++ b/lib/PhpParser/BuilderHelpers.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser;
 
 use PhpParser\Node\Expr;

--- a/lib/PhpParser/Comment.php
+++ b/lib/PhpParser/Comment.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser;
 
 class Comment implements \JsonSerializable

--- a/lib/PhpParser/Comment/Doc.php
+++ b/lib/PhpParser/Comment/Doc.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Comment;
 
 class Doc extends \PhpParser\Comment

--- a/lib/PhpParser/Error.php
+++ b/lib/PhpParser/Error.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser;
 
 class Error extends \RuntimeException

--- a/lib/PhpParser/ErrorHandler.php
+++ b/lib/PhpParser/ErrorHandler.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser;
 
 interface ErrorHandler

--- a/lib/PhpParser/ErrorHandler/Collecting.php
+++ b/lib/PhpParser/ErrorHandler/Collecting.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\ErrorHandler;
 
 use PhpParser\Error;

--- a/lib/PhpParser/ErrorHandler/Throwing.php
+++ b/lib/PhpParser/ErrorHandler/Throwing.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\ErrorHandler;
 
 use PhpParser\Error;

--- a/lib/PhpParser/Lexer.php
+++ b/lib/PhpParser/Lexer.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser;
 
 use PhpParser\Parser\Tokens;

--- a/lib/PhpParser/Lexer/Emulative.php
+++ b/lib/PhpParser/Lexer/Emulative.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Lexer;
 
 

--- a/lib/PhpParser/NameContext.php
+++ b/lib/PhpParser/NameContext.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser;
 
 use PhpParser\Node\Name;
@@ -187,7 +189,7 @@ class NameContext {
         foreach ($this->origAliases[$type] as $alias => $orig) {
             if ($type === Stmt\Use_::TYPE_CONSTANT) {
                 // Constants are are complicated-sensitive
-                if ($this->normalizeConstName($orig) === $this->normalizeConstName($name)) {
+                if ($this->normalizeConstName((string) $orig) === $this->normalizeConstName($name)) {
                     $possibleNames[] = new Name($alias);
                 }
             } else {

--- a/lib/PhpParser/Node.php
+++ b/lib/PhpParser/Node.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser;
 
 interface Node

--- a/lib/PhpParser/Node/Arg.php
+++ b/lib/PhpParser/Node/Arg.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node;
 
 use PhpParser\NodeAbstract;

--- a/lib/PhpParser/Node/Const_.php
+++ b/lib/PhpParser/Node/Const_.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node;
 
 use PhpParser\NodeAbstract;

--- a/lib/PhpParser/Node/Expr.php
+++ b/lib/PhpParser/Node/Expr.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node;
 
 use PhpParser\NodeAbstract;

--- a/lib/PhpParser/Node/Expr/ArrayDimFetch.php
+++ b/lib/PhpParser/Node/Expr/ArrayDimFetch.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Expr;
 
 use PhpParser\Node\Expr;

--- a/lib/PhpParser/Node/Expr/ArrayItem.php
+++ b/lib/PhpParser/Node/Expr/ArrayItem.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Expr;
 
 use PhpParser\Node\Expr;

--- a/lib/PhpParser/Node/Expr/Array_.php
+++ b/lib/PhpParser/Node/Expr/Array_.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Expr;
 
 use PhpParser\Node\Expr;

--- a/lib/PhpParser/Node/Expr/Assign.php
+++ b/lib/PhpParser/Node/Expr/Assign.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Expr;
 
 use PhpParser\Node\Expr;

--- a/lib/PhpParser/Node/Expr/AssignOp.php
+++ b/lib/PhpParser/Node/Expr/AssignOp.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Expr;
 
 use PhpParser\Node\Expr;

--- a/lib/PhpParser/Node/Expr/AssignOp/BitwiseAnd.php
+++ b/lib/PhpParser/Node/Expr/AssignOp/BitwiseAnd.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Expr\AssignOp;
 
 use PhpParser\Node\Expr\AssignOp;

--- a/lib/PhpParser/Node/Expr/AssignOp/BitwiseOr.php
+++ b/lib/PhpParser/Node/Expr/AssignOp/BitwiseOr.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Expr\AssignOp;
 
 use PhpParser\Node\Expr\AssignOp;

--- a/lib/PhpParser/Node/Expr/AssignOp/BitwiseXor.php
+++ b/lib/PhpParser/Node/Expr/AssignOp/BitwiseXor.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Expr\AssignOp;
 
 use PhpParser\Node\Expr\AssignOp;

--- a/lib/PhpParser/Node/Expr/AssignOp/Concat.php
+++ b/lib/PhpParser/Node/Expr/AssignOp/Concat.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Expr\AssignOp;
 
 use PhpParser\Node\Expr\AssignOp;

--- a/lib/PhpParser/Node/Expr/AssignOp/Div.php
+++ b/lib/PhpParser/Node/Expr/AssignOp/Div.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Expr\AssignOp;
 
 use PhpParser\Node\Expr\AssignOp;

--- a/lib/PhpParser/Node/Expr/AssignOp/Minus.php
+++ b/lib/PhpParser/Node/Expr/AssignOp/Minus.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Expr\AssignOp;
 
 use PhpParser\Node\Expr\AssignOp;

--- a/lib/PhpParser/Node/Expr/AssignOp/Mod.php
+++ b/lib/PhpParser/Node/Expr/AssignOp/Mod.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Expr\AssignOp;
 
 use PhpParser\Node\Expr\AssignOp;

--- a/lib/PhpParser/Node/Expr/AssignOp/Mul.php
+++ b/lib/PhpParser/Node/Expr/AssignOp/Mul.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Expr\AssignOp;
 
 use PhpParser\Node\Expr\AssignOp;

--- a/lib/PhpParser/Node/Expr/AssignOp/Plus.php
+++ b/lib/PhpParser/Node/Expr/AssignOp/Plus.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Expr\AssignOp;
 
 use PhpParser\Node\Expr\AssignOp;

--- a/lib/PhpParser/Node/Expr/AssignOp/Pow.php
+++ b/lib/PhpParser/Node/Expr/AssignOp/Pow.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Expr\AssignOp;
 
 use PhpParser\Node\Expr\AssignOp;

--- a/lib/PhpParser/Node/Expr/AssignOp/ShiftLeft.php
+++ b/lib/PhpParser/Node/Expr/AssignOp/ShiftLeft.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Expr\AssignOp;
 
 use PhpParser\Node\Expr\AssignOp;

--- a/lib/PhpParser/Node/Expr/AssignOp/ShiftRight.php
+++ b/lib/PhpParser/Node/Expr/AssignOp/ShiftRight.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Expr\AssignOp;
 
 use PhpParser\Node\Expr\AssignOp;

--- a/lib/PhpParser/Node/Expr/AssignRef.php
+++ b/lib/PhpParser/Node/Expr/AssignRef.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Expr;
 
 use PhpParser\Node\Expr;

--- a/lib/PhpParser/Node/Expr/BinaryOp.php
+++ b/lib/PhpParser/Node/Expr/BinaryOp.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Expr;
 
 use PhpParser\Node\Expr;

--- a/lib/PhpParser/Node/Expr/BinaryOp/BitwiseAnd.php
+++ b/lib/PhpParser/Node/Expr/BinaryOp/BitwiseAnd.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Expr\BinaryOp;
 
 use PhpParser\Node\Expr\BinaryOp;

--- a/lib/PhpParser/Node/Expr/BinaryOp/BitwiseOr.php
+++ b/lib/PhpParser/Node/Expr/BinaryOp/BitwiseOr.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Expr\BinaryOp;
 
 use PhpParser\Node\Expr\BinaryOp;

--- a/lib/PhpParser/Node/Expr/BinaryOp/BitwiseXor.php
+++ b/lib/PhpParser/Node/Expr/BinaryOp/BitwiseXor.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Expr\BinaryOp;
 
 use PhpParser\Node\Expr\BinaryOp;

--- a/lib/PhpParser/Node/Expr/BinaryOp/BooleanAnd.php
+++ b/lib/PhpParser/Node/Expr/BinaryOp/BooleanAnd.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Expr\BinaryOp;
 
 use PhpParser\Node\Expr\BinaryOp;

--- a/lib/PhpParser/Node/Expr/BinaryOp/BooleanOr.php
+++ b/lib/PhpParser/Node/Expr/BinaryOp/BooleanOr.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Expr\BinaryOp;
 
 use PhpParser\Node\Expr\BinaryOp;

--- a/lib/PhpParser/Node/Expr/BinaryOp/Coalesce.php
+++ b/lib/PhpParser/Node/Expr/BinaryOp/Coalesce.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Expr\BinaryOp;
 
 use PhpParser\Node\Expr\BinaryOp;

--- a/lib/PhpParser/Node/Expr/BinaryOp/Concat.php
+++ b/lib/PhpParser/Node/Expr/BinaryOp/Concat.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Expr\BinaryOp;
 
 use PhpParser\Node\Expr\BinaryOp;

--- a/lib/PhpParser/Node/Expr/BinaryOp/Div.php
+++ b/lib/PhpParser/Node/Expr/BinaryOp/Div.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Expr\BinaryOp;
 
 use PhpParser\Node\Expr\BinaryOp;

--- a/lib/PhpParser/Node/Expr/BinaryOp/Equal.php
+++ b/lib/PhpParser/Node/Expr/BinaryOp/Equal.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Expr\BinaryOp;
 
 use PhpParser\Node\Expr\BinaryOp;

--- a/lib/PhpParser/Node/Expr/BinaryOp/Greater.php
+++ b/lib/PhpParser/Node/Expr/BinaryOp/Greater.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Expr\BinaryOp;
 
 use PhpParser\Node\Expr\BinaryOp;

--- a/lib/PhpParser/Node/Expr/BinaryOp/GreaterOrEqual.php
+++ b/lib/PhpParser/Node/Expr/BinaryOp/GreaterOrEqual.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Expr\BinaryOp;
 
 use PhpParser\Node\Expr\BinaryOp;

--- a/lib/PhpParser/Node/Expr/BinaryOp/Identical.php
+++ b/lib/PhpParser/Node/Expr/BinaryOp/Identical.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Expr\BinaryOp;
 
 use PhpParser\Node\Expr\BinaryOp;

--- a/lib/PhpParser/Node/Expr/BinaryOp/LogicalAnd.php
+++ b/lib/PhpParser/Node/Expr/BinaryOp/LogicalAnd.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Expr\BinaryOp;
 
 use PhpParser\Node\Expr\BinaryOp;

--- a/lib/PhpParser/Node/Expr/BinaryOp/LogicalOr.php
+++ b/lib/PhpParser/Node/Expr/BinaryOp/LogicalOr.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Expr\BinaryOp;
 
 use PhpParser\Node\Expr\BinaryOp;

--- a/lib/PhpParser/Node/Expr/BinaryOp/LogicalXor.php
+++ b/lib/PhpParser/Node/Expr/BinaryOp/LogicalXor.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Expr\BinaryOp;
 
 use PhpParser\Node\Expr\BinaryOp;

--- a/lib/PhpParser/Node/Expr/BinaryOp/Minus.php
+++ b/lib/PhpParser/Node/Expr/BinaryOp/Minus.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Expr\BinaryOp;
 
 use PhpParser\Node\Expr\BinaryOp;

--- a/lib/PhpParser/Node/Expr/BinaryOp/Mod.php
+++ b/lib/PhpParser/Node/Expr/BinaryOp/Mod.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Expr\BinaryOp;
 
 use PhpParser\Node\Expr\BinaryOp;

--- a/lib/PhpParser/Node/Expr/BinaryOp/Mul.php
+++ b/lib/PhpParser/Node/Expr/BinaryOp/Mul.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Expr\BinaryOp;
 
 use PhpParser\Node\Expr\BinaryOp;

--- a/lib/PhpParser/Node/Expr/BinaryOp/NotEqual.php
+++ b/lib/PhpParser/Node/Expr/BinaryOp/NotEqual.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Expr\BinaryOp;
 
 use PhpParser\Node\Expr\BinaryOp;

--- a/lib/PhpParser/Node/Expr/BinaryOp/NotIdentical.php
+++ b/lib/PhpParser/Node/Expr/BinaryOp/NotIdentical.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Expr\BinaryOp;
 
 use PhpParser\Node\Expr\BinaryOp;

--- a/lib/PhpParser/Node/Expr/BinaryOp/Plus.php
+++ b/lib/PhpParser/Node/Expr/BinaryOp/Plus.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Expr\BinaryOp;
 
 use PhpParser\Node\Expr\BinaryOp;

--- a/lib/PhpParser/Node/Expr/BinaryOp/Pow.php
+++ b/lib/PhpParser/Node/Expr/BinaryOp/Pow.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Expr\BinaryOp;
 
 use PhpParser\Node\Expr\BinaryOp;

--- a/lib/PhpParser/Node/Expr/BinaryOp/ShiftLeft.php
+++ b/lib/PhpParser/Node/Expr/BinaryOp/ShiftLeft.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Expr\BinaryOp;
 
 use PhpParser\Node\Expr\BinaryOp;

--- a/lib/PhpParser/Node/Expr/BinaryOp/ShiftRight.php
+++ b/lib/PhpParser/Node/Expr/BinaryOp/ShiftRight.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Expr\BinaryOp;
 
 use PhpParser\Node\Expr\BinaryOp;

--- a/lib/PhpParser/Node/Expr/BinaryOp/Smaller.php
+++ b/lib/PhpParser/Node/Expr/BinaryOp/Smaller.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Expr\BinaryOp;
 
 use PhpParser\Node\Expr\BinaryOp;

--- a/lib/PhpParser/Node/Expr/BinaryOp/SmallerOrEqual.php
+++ b/lib/PhpParser/Node/Expr/BinaryOp/SmallerOrEqual.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Expr\BinaryOp;
 
 use PhpParser\Node\Expr\BinaryOp;

--- a/lib/PhpParser/Node/Expr/BinaryOp/Spaceship.php
+++ b/lib/PhpParser/Node/Expr/BinaryOp/Spaceship.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Expr\BinaryOp;
 
 use PhpParser\Node\Expr\BinaryOp;

--- a/lib/PhpParser/Node/Expr/BitwiseNot.php
+++ b/lib/PhpParser/Node/Expr/BitwiseNot.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Expr;
 
 use PhpParser\Node\Expr;

--- a/lib/PhpParser/Node/Expr/BooleanNot.php
+++ b/lib/PhpParser/Node/Expr/BooleanNot.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Expr;
 
 use PhpParser\Node\Expr;

--- a/lib/PhpParser/Node/Expr/Cast.php
+++ b/lib/PhpParser/Node/Expr/Cast.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Expr;
 
 use PhpParser\Node\Expr;

--- a/lib/PhpParser/Node/Expr/Cast/Array_.php
+++ b/lib/PhpParser/Node/Expr/Cast/Array_.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Expr\Cast;
 
 use PhpParser\Node\Expr\Cast;

--- a/lib/PhpParser/Node/Expr/Cast/Bool_.php
+++ b/lib/PhpParser/Node/Expr/Cast/Bool_.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Expr\Cast;
 
 use PhpParser\Node\Expr\Cast;

--- a/lib/PhpParser/Node/Expr/Cast/Double.php
+++ b/lib/PhpParser/Node/Expr/Cast/Double.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Expr\Cast;
 
 use PhpParser\Node\Expr\Cast;

--- a/lib/PhpParser/Node/Expr/Cast/Int_.php
+++ b/lib/PhpParser/Node/Expr/Cast/Int_.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Expr\Cast;
 
 use PhpParser\Node\Expr\Cast;

--- a/lib/PhpParser/Node/Expr/Cast/Object_.php
+++ b/lib/PhpParser/Node/Expr/Cast/Object_.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Expr\Cast;
 
 use PhpParser\Node\Expr\Cast;

--- a/lib/PhpParser/Node/Expr/Cast/String_.php
+++ b/lib/PhpParser/Node/Expr/Cast/String_.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Expr\Cast;
 
 use PhpParser\Node\Expr\Cast;

--- a/lib/PhpParser/Node/Expr/Cast/Unset_.php
+++ b/lib/PhpParser/Node/Expr/Cast/Unset_.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Expr\Cast;
 
 use PhpParser\Node\Expr\Cast;

--- a/lib/PhpParser/Node/Expr/ClassConstFetch.php
+++ b/lib/PhpParser/Node/Expr/ClassConstFetch.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Expr;
 
 use PhpParser\Node\Expr;

--- a/lib/PhpParser/Node/Expr/Clone_.php
+++ b/lib/PhpParser/Node/Expr/Clone_.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Expr;
 
 use PhpParser\Node\Expr;

--- a/lib/PhpParser/Node/Expr/Closure.php
+++ b/lib/PhpParser/Node/Expr/Closure.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Expr;
 
 use PhpParser\Node;

--- a/lib/PhpParser/Node/Expr/ClosureUse.php
+++ b/lib/PhpParser/Node/Expr/ClosureUse.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Expr;
 
 use PhpParser\Node\Expr;

--- a/lib/PhpParser/Node/Expr/ConstFetch.php
+++ b/lib/PhpParser/Node/Expr/ConstFetch.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Expr;
 
 use PhpParser\Node\Expr;

--- a/lib/PhpParser/Node/Expr/Empty_.php
+++ b/lib/PhpParser/Node/Expr/Empty_.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Expr;
 
 use PhpParser\Node\Expr;

--- a/lib/PhpParser/Node/Expr/Error.php
+++ b/lib/PhpParser/Node/Expr/Error.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Expr;
 
 use PhpParser\Node\Expr;

--- a/lib/PhpParser/Node/Expr/ErrorSuppress.php
+++ b/lib/PhpParser/Node/Expr/ErrorSuppress.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Expr;
 
 use PhpParser\Node\Expr;

--- a/lib/PhpParser/Node/Expr/Eval_.php
+++ b/lib/PhpParser/Node/Expr/Eval_.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Expr;
 
 use PhpParser\Node\Expr;

--- a/lib/PhpParser/Node/Expr/Exit_.php
+++ b/lib/PhpParser/Node/Expr/Exit_.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Expr;
 
 use PhpParser\Node\Expr;

--- a/lib/PhpParser/Node/Expr/FuncCall.php
+++ b/lib/PhpParser/Node/Expr/FuncCall.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Expr;
 
 use PhpParser\Node;

--- a/lib/PhpParser/Node/Expr/Include_.php
+++ b/lib/PhpParser/Node/Expr/Include_.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Expr;
 
 use PhpParser\Node\Expr;

--- a/lib/PhpParser/Node/Expr/Instanceof_.php
+++ b/lib/PhpParser/Node/Expr/Instanceof_.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Expr;
 
 use PhpParser\Node\Expr;

--- a/lib/PhpParser/Node/Expr/Isset_.php
+++ b/lib/PhpParser/Node/Expr/Isset_.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Expr;
 
 use PhpParser\Node\Expr;

--- a/lib/PhpParser/Node/Expr/List_.php
+++ b/lib/PhpParser/Node/Expr/List_.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Expr;
 
 use PhpParser\Node\Expr;

--- a/lib/PhpParser/Node/Expr/MethodCall.php
+++ b/lib/PhpParser/Node/Expr/MethodCall.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Expr;
 
 use PhpParser\Node\Arg;

--- a/lib/PhpParser/Node/Expr/New_.php
+++ b/lib/PhpParser/Node/Expr/New_.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Expr;
 
 use PhpParser\Node;

--- a/lib/PhpParser/Node/Expr/PostDec.php
+++ b/lib/PhpParser/Node/Expr/PostDec.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Expr;
 
 use PhpParser\Node\Expr;

--- a/lib/PhpParser/Node/Expr/PostInc.php
+++ b/lib/PhpParser/Node/Expr/PostInc.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Expr;
 
 use PhpParser\Node\Expr;

--- a/lib/PhpParser/Node/Expr/PreDec.php
+++ b/lib/PhpParser/Node/Expr/PreDec.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Expr;
 
 use PhpParser\Node\Expr;

--- a/lib/PhpParser/Node/Expr/PreInc.php
+++ b/lib/PhpParser/Node/Expr/PreInc.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Expr;
 
 use PhpParser\Node\Expr;

--- a/lib/PhpParser/Node/Expr/Print_.php
+++ b/lib/PhpParser/Node/Expr/Print_.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Expr;
 
 use PhpParser\Node\Expr;

--- a/lib/PhpParser/Node/Expr/PropertyFetch.php
+++ b/lib/PhpParser/Node/Expr/PropertyFetch.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Expr;
 
 use PhpParser\Node\Expr;

--- a/lib/PhpParser/Node/Expr/ShellExec.php
+++ b/lib/PhpParser/Node/Expr/ShellExec.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Expr;
 
 use PhpParser\Node\Expr;

--- a/lib/PhpParser/Node/Expr/StaticCall.php
+++ b/lib/PhpParser/Node/Expr/StaticCall.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Expr;
 
 use PhpParser\Node;

--- a/lib/PhpParser/Node/Expr/StaticPropertyFetch.php
+++ b/lib/PhpParser/Node/Expr/StaticPropertyFetch.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Expr;
 
 use PhpParser\Node\Expr;

--- a/lib/PhpParser/Node/Expr/Ternary.php
+++ b/lib/PhpParser/Node/Expr/Ternary.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Expr;
 
 use PhpParser\Node\Expr;

--- a/lib/PhpParser/Node/Expr/UnaryMinus.php
+++ b/lib/PhpParser/Node/Expr/UnaryMinus.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Expr;
 
 use PhpParser\Node\Expr;

--- a/lib/PhpParser/Node/Expr/UnaryPlus.php
+++ b/lib/PhpParser/Node/Expr/UnaryPlus.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Expr;
 
 use PhpParser\Node\Expr;

--- a/lib/PhpParser/Node/Expr/Variable.php
+++ b/lib/PhpParser/Node/Expr/Variable.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Expr;
 
 use PhpParser\Node\Expr;

--- a/lib/PhpParser/Node/Expr/YieldFrom.php
+++ b/lib/PhpParser/Node/Expr/YieldFrom.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Expr;
 
 use PhpParser\Node\Expr;

--- a/lib/PhpParser/Node/Expr/Yield_.php
+++ b/lib/PhpParser/Node/Expr/Yield_.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Expr;
 
 use PhpParser\Node\Expr;

--- a/lib/PhpParser/Node/FunctionLike.php
+++ b/lib/PhpParser/Node/FunctionLike.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node;
 
 use PhpParser\Node;

--- a/lib/PhpParser/Node/Identifier.php
+++ b/lib/PhpParser/Node/Identifier.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node;
 
 use PhpParser\NodeAbstract;

--- a/lib/PhpParser/Node/Name.php
+++ b/lib/PhpParser/Node/Name.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node;
 
 use PhpParser\NodeAbstract;

--- a/lib/PhpParser/Node/Name/FullyQualified.php
+++ b/lib/PhpParser/Node/Name/FullyQualified.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Name;
 
 class FullyQualified extends \PhpParser\Node\Name

--- a/lib/PhpParser/Node/Name/Relative.php
+++ b/lib/PhpParser/Node/Name/Relative.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Name;
 
 class Relative extends \PhpParser\Node\Name

--- a/lib/PhpParser/Node/NullableType.php
+++ b/lib/PhpParser/Node/NullableType.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node;
 
 use PhpParser\NodeAbstract;

--- a/lib/PhpParser/Node/Param.php
+++ b/lib/PhpParser/Node/Param.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node;
 
 use PhpParser\NodeAbstract;

--- a/lib/PhpParser/Node/Scalar.php
+++ b/lib/PhpParser/Node/Scalar.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node;
 
 abstract class Scalar extends Expr

--- a/lib/PhpParser/Node/Scalar/DNumber.php
+++ b/lib/PhpParser/Node/Scalar/DNumber.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Scalar;
 
 use PhpParser\Node\Scalar;

--- a/lib/PhpParser/Node/Scalar/Encapsed.php
+++ b/lib/PhpParser/Node/Scalar/Encapsed.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Scalar;
 
 use PhpParser\Node\Expr;

--- a/lib/PhpParser/Node/Scalar/EncapsedStringPart.php
+++ b/lib/PhpParser/Node/Scalar/EncapsedStringPart.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Scalar;
 
 use PhpParser\Node\Scalar;

--- a/lib/PhpParser/Node/Scalar/LNumber.php
+++ b/lib/PhpParser/Node/Scalar/LNumber.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Scalar;
 
 use PhpParser\Error;

--- a/lib/PhpParser/Node/Scalar/MagicConst.php
+++ b/lib/PhpParser/Node/Scalar/MagicConst.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Scalar;
 
 use PhpParser\Node\Scalar;

--- a/lib/PhpParser/Node/Scalar/MagicConst/Class_.php
+++ b/lib/PhpParser/Node/Scalar/MagicConst/Class_.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Scalar\MagicConst;
 
 use PhpParser\Node\Scalar\MagicConst;

--- a/lib/PhpParser/Node/Scalar/MagicConst/Dir.php
+++ b/lib/PhpParser/Node/Scalar/MagicConst/Dir.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Scalar\MagicConst;
 
 use PhpParser\Node\Scalar\MagicConst;

--- a/lib/PhpParser/Node/Scalar/MagicConst/File.php
+++ b/lib/PhpParser/Node/Scalar/MagicConst/File.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Scalar\MagicConst;
 
 use PhpParser\Node\Scalar\MagicConst;

--- a/lib/PhpParser/Node/Scalar/MagicConst/Function_.php
+++ b/lib/PhpParser/Node/Scalar/MagicConst/Function_.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Scalar\MagicConst;
 
 use PhpParser\Node\Scalar\MagicConst;

--- a/lib/PhpParser/Node/Scalar/MagicConst/Line.php
+++ b/lib/PhpParser/Node/Scalar/MagicConst/Line.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Scalar\MagicConst;
 
 use PhpParser\Node\Scalar\MagicConst;

--- a/lib/PhpParser/Node/Scalar/MagicConst/Method.php
+++ b/lib/PhpParser/Node/Scalar/MagicConst/Method.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Scalar\MagicConst;
 
 use PhpParser\Node\Scalar\MagicConst;

--- a/lib/PhpParser/Node/Scalar/MagicConst/Namespace_.php
+++ b/lib/PhpParser/Node/Scalar/MagicConst/Namespace_.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Scalar\MagicConst;
 
 use PhpParser\Node\Scalar\MagicConst;

--- a/lib/PhpParser/Node/Scalar/MagicConst/Trait_.php
+++ b/lib/PhpParser/Node/Scalar/MagicConst/Trait_.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Scalar\MagicConst;
 
 use PhpParser\Node\Scalar\MagicConst;

--- a/lib/PhpParser/Node/Scalar/String_.php
+++ b/lib/PhpParser/Node/Scalar/String_.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Scalar;
 
 use PhpParser\Error;

--- a/lib/PhpParser/Node/Stmt.php
+++ b/lib/PhpParser/Node/Stmt.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node;
 
 use PhpParser\NodeAbstract;

--- a/lib/PhpParser/Node/Stmt/Break_.php
+++ b/lib/PhpParser/Node/Stmt/Break_.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Stmt;
 
 use PhpParser\Node;

--- a/lib/PhpParser/Node/Stmt/Case_.php
+++ b/lib/PhpParser/Node/Stmt/Case_.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Stmt;
 
 use PhpParser\Node;

--- a/lib/PhpParser/Node/Stmt/Catch_.php
+++ b/lib/PhpParser/Node/Stmt/Catch_.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Stmt;
 
 use PhpParser\Node;

--- a/lib/PhpParser/Node/Stmt/ClassConst.php
+++ b/lib/PhpParser/Node/Stmt/ClassConst.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Stmt;
 
 use PhpParser\Node;

--- a/lib/PhpParser/Node/Stmt/ClassLike.php
+++ b/lib/PhpParser/Node/Stmt/ClassLike.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Stmt;
 
 use PhpParser\Node;
@@ -38,7 +40,7 @@ abstract class ClassLike extends Node\Stmt {
     public function getMethod(string $name) {
         $lowerName = strtolower($name);
         foreach ($this->stmts as $stmt) {
-            if ($stmt instanceof ClassMethod && $lowerName === strtolower($stmt->name)) {
+            if ($stmt instanceof ClassMethod && $lowerName === strtolower((string) $stmt->name)) {
                 return $stmt;
             }
         }

--- a/lib/PhpParser/Node/Stmt/ClassMethod.php
+++ b/lib/PhpParser/Node/Stmt/ClassMethod.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Stmt;
 
 use PhpParser\Node;
@@ -142,6 +144,6 @@ class ClassMethod extends Node\Stmt implements FunctionLike
      * @return bool
      */
     public function isMagic() : bool {
-        return isset(self::$magicNames[strtolower($this->name)]);
+        return isset(self::$magicNames[strtolower((string) $this->name)]);
     }
 }

--- a/lib/PhpParser/Node/Stmt/Class_.php
+++ b/lib/PhpParser/Node/Stmt/Class_.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Stmt;
 
 use PhpParser\Error;

--- a/lib/PhpParser/Node/Stmt/Const_.php
+++ b/lib/PhpParser/Node/Stmt/Const_.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Stmt;
 
 use PhpParser\Node;

--- a/lib/PhpParser/Node/Stmt/Continue_.php
+++ b/lib/PhpParser/Node/Stmt/Continue_.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Stmt;
 
 use PhpParser\Node;

--- a/lib/PhpParser/Node/Stmt/DeclareDeclare.php
+++ b/lib/PhpParser/Node/Stmt/DeclareDeclare.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Stmt;
 
 use PhpParser\Node;

--- a/lib/PhpParser/Node/Stmt/Declare_.php
+++ b/lib/PhpParser/Node/Stmt/Declare_.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Stmt;
 
 use PhpParser\Node;

--- a/lib/PhpParser/Node/Stmt/Do_.php
+++ b/lib/PhpParser/Node/Stmt/Do_.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Stmt;
 
 use PhpParser\Node;

--- a/lib/PhpParser/Node/Stmt/Echo_.php
+++ b/lib/PhpParser/Node/Stmt/Echo_.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Stmt;
 
 use PhpParser\Node;

--- a/lib/PhpParser/Node/Stmt/ElseIf_.php
+++ b/lib/PhpParser/Node/Stmt/ElseIf_.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Stmt;
 
 use PhpParser\Node;

--- a/lib/PhpParser/Node/Stmt/Else_.php
+++ b/lib/PhpParser/Node/Stmt/Else_.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Stmt;
 
 use PhpParser\Node;

--- a/lib/PhpParser/Node/Stmt/Expression.php
+++ b/lib/PhpParser/Node/Stmt/Expression.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Stmt;
 
 use PhpParser\Node;

--- a/lib/PhpParser/Node/Stmt/Finally_.php
+++ b/lib/PhpParser/Node/Stmt/Finally_.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Stmt;
 
 use PhpParser\Node;

--- a/lib/PhpParser/Node/Stmt/For_.php
+++ b/lib/PhpParser/Node/Stmt/For_.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Stmt;
 
 use PhpParser\Node;

--- a/lib/PhpParser/Node/Stmt/Foreach_.php
+++ b/lib/PhpParser/Node/Stmt/Foreach_.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Stmt;
 
 use PhpParser\Node;

--- a/lib/PhpParser/Node/Stmt/Function_.php
+++ b/lib/PhpParser/Node/Stmt/Function_.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Stmt;
 
 use PhpParser\Node;

--- a/lib/PhpParser/Node/Stmt/Global_.php
+++ b/lib/PhpParser/Node/Stmt/Global_.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Stmt;
 
 use PhpParser\Node;

--- a/lib/PhpParser/Node/Stmt/Goto_.php
+++ b/lib/PhpParser/Node/Stmt/Goto_.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Stmt;
 
 use PhpParser\Node\Identifier;

--- a/lib/PhpParser/Node/Stmt/GroupUse.php
+++ b/lib/PhpParser/Node/Stmt/GroupUse.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Stmt;
 
 use PhpParser\Node\Name;

--- a/lib/PhpParser/Node/Stmt/HaltCompiler.php
+++ b/lib/PhpParser/Node/Stmt/HaltCompiler.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Stmt;
 
 use PhpParser\Node\Stmt;

--- a/lib/PhpParser/Node/Stmt/If_.php
+++ b/lib/PhpParser/Node/Stmt/If_.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Stmt;
 
 use PhpParser\Node;

--- a/lib/PhpParser/Node/Stmt/InlineHTML.php
+++ b/lib/PhpParser/Node/Stmt/InlineHTML.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Stmt;
 
 use PhpParser\Node\Stmt;

--- a/lib/PhpParser/Node/Stmt/Interface_.php
+++ b/lib/PhpParser/Node/Stmt/Interface_.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Stmt;
 
 use PhpParser\Node;

--- a/lib/PhpParser/Node/Stmt/Label.php
+++ b/lib/PhpParser/Node/Stmt/Label.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Stmt;
 
 use PhpParser\Node\Identifier;

--- a/lib/PhpParser/Node/Stmt/Namespace_.php
+++ b/lib/PhpParser/Node/Stmt/Namespace_.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Stmt;
 
 use PhpParser\Node;

--- a/lib/PhpParser/Node/Stmt/Nop.php
+++ b/lib/PhpParser/Node/Stmt/Nop.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Stmt;
 
 use PhpParser\Node;

--- a/lib/PhpParser/Node/Stmt/Property.php
+++ b/lib/PhpParser/Node/Stmt/Property.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Stmt;
 
 use PhpParser\Node;

--- a/lib/PhpParser/Node/Stmt/PropertyProperty.php
+++ b/lib/PhpParser/Node/Stmt/PropertyProperty.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Stmt;
 
 use PhpParser\Node;

--- a/lib/PhpParser/Node/Stmt/Return_.php
+++ b/lib/PhpParser/Node/Stmt/Return_.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Stmt;
 
 use PhpParser\Node;

--- a/lib/PhpParser/Node/Stmt/StaticVar.php
+++ b/lib/PhpParser/Node/Stmt/StaticVar.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Stmt;
 
 use PhpParser\Node;

--- a/lib/PhpParser/Node/Stmt/Static_.php
+++ b/lib/PhpParser/Node/Stmt/Static_.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Stmt;
 
 use PhpParser\Node\Stmt;

--- a/lib/PhpParser/Node/Stmt/Switch_.php
+++ b/lib/PhpParser/Node/Stmt/Switch_.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Stmt;
 
 use PhpParser\Node;

--- a/lib/PhpParser/Node/Stmt/Throw_.php
+++ b/lib/PhpParser/Node/Stmt/Throw_.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Stmt;
 
 use PhpParser\Node;

--- a/lib/PhpParser/Node/Stmt/TraitUse.php
+++ b/lib/PhpParser/Node/Stmt/TraitUse.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Stmt;
 
 use PhpParser\Node;

--- a/lib/PhpParser/Node/Stmt/TraitUseAdaptation.php
+++ b/lib/PhpParser/Node/Stmt/TraitUseAdaptation.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Stmt;
 
 use PhpParser\Node;

--- a/lib/PhpParser/Node/Stmt/TraitUseAdaptation/Alias.php
+++ b/lib/PhpParser/Node/Stmt/TraitUseAdaptation/Alias.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Stmt\TraitUseAdaptation;
 
 use PhpParser\Node;

--- a/lib/PhpParser/Node/Stmt/TraitUseAdaptation/Precedence.php
+++ b/lib/PhpParser/Node/Stmt/TraitUseAdaptation/Precedence.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Stmt\TraitUseAdaptation;
 
 use PhpParser\Node;

--- a/lib/PhpParser/Node/Stmt/Trait_.php
+++ b/lib/PhpParser/Node/Stmt/Trait_.php
@@ -19,7 +19,7 @@ class Trait_ extends ClassLike
     public function __construct($name, array $subNodes = [], array $attributes = []) {
         parent::__construct($attributes);
         $this->name = \is_string($name) ? new Node\Identifier($name) : $name;
-        $this->stmts = isset($subNodes['stmts']) ? $subNodes['stmts'] : [];
+        $this->stmts = $subNodes['stmts'] ?? [];
     }
 
     public function getSubNodeNames() : array {

--- a/lib/PhpParser/Node/Stmt/Trait_.php
+++ b/lib/PhpParser/Node/Stmt/Trait_.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Stmt;
 
 use PhpParser\Node;

--- a/lib/PhpParser/Node/Stmt/TryCatch.php
+++ b/lib/PhpParser/Node/Stmt/TryCatch.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Stmt;
 
 use PhpParser\Node;

--- a/lib/PhpParser/Node/Stmt/Unset_.php
+++ b/lib/PhpParser/Node/Stmt/Unset_.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Stmt;
 
 use PhpParser\Node;

--- a/lib/PhpParser/Node/Stmt/UseUse.php
+++ b/lib/PhpParser/Node/Stmt/UseUse.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Stmt;
 
 use PhpParser\Node;

--- a/lib/PhpParser/Node/Stmt/Use_.php
+++ b/lib/PhpParser/Node/Stmt/Use_.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Stmt;
 
 use PhpParser\Node\Stmt;

--- a/lib/PhpParser/Node/Stmt/While_.php
+++ b/lib/PhpParser/Node/Stmt/While_.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Stmt;
 
 use PhpParser\Node;

--- a/lib/PhpParser/Node/VarLikeIdentifier.php
+++ b/lib/PhpParser/Node/VarLikeIdentifier.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node;
 
 /**

--- a/lib/PhpParser/NodeAbstract.php
+++ b/lib/PhpParser/NodeAbstract.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser;
 
 abstract class NodeAbstract implements Node, \JsonSerializable

--- a/lib/PhpParser/NodeDumper.php
+++ b/lib/PhpParser/NodeDumper.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser;
 
 use PhpParser\Node\Expr\Include_;

--- a/lib/PhpParser/NodeFinder.php
+++ b/lib/PhpParser/NodeFinder.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser;
 
 use PhpParser\NodeVisitor\FindingVisitor;

--- a/lib/PhpParser/NodeTraverser.php
+++ b/lib/PhpParser/NodeTraverser.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser;
 
 class NodeTraverser implements NodeTraverserInterface

--- a/lib/PhpParser/NodeTraverserInterface.php
+++ b/lib/PhpParser/NodeTraverserInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser;
 
 interface NodeTraverserInterface

--- a/lib/PhpParser/NodeVisitor.php
+++ b/lib/PhpParser/NodeVisitor.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser;
 
 interface NodeVisitor

--- a/lib/PhpParser/NodeVisitor/CloningVisitor.php
+++ b/lib/PhpParser/NodeVisitor/CloningVisitor.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\NodeVisitor;
 
 use PhpParser\Node;

--- a/lib/PhpParser/NodeVisitor/FindingVisitor.php
+++ b/lib/PhpParser/NodeVisitor/FindingVisitor.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\NodeVisitor;
 
 use PhpParser\Node;

--- a/lib/PhpParser/NodeVisitor/FirstFindingVisitor.php
+++ b/lib/PhpParser/NodeVisitor/FirstFindingVisitor.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\NodeVisitor;
 
 use PhpParser\Node;

--- a/lib/PhpParser/NodeVisitor/NameResolver.php
+++ b/lib/PhpParser/NodeVisitor/NameResolver.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\NodeVisitor;
 
 use PhpParser\Error;

--- a/lib/PhpParser/NodeVisitorAbstract.php
+++ b/lib/PhpParser/NodeVisitorAbstract.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser;
 
 /**

--- a/lib/PhpParser/Parser.php
+++ b/lib/PhpParser/Parser.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser;
 
 interface Parser {

--- a/lib/PhpParser/Parser/Multiple.php
+++ b/lib/PhpParser/Parser/Multiple.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Parser;
 
 use PhpParser\Error;

--- a/lib/PhpParser/Parser/Php5.php
+++ b/lib/PhpParser/Parser/Php5.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Parser;
 
 use PhpParser\Error;

--- a/lib/PhpParser/Parser/Php7.php
+++ b/lib/PhpParser/Parser/Php7.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Parser;
 
 use PhpParser\Error;

--- a/lib/PhpParser/Parser/Tokens.php
+++ b/lib/PhpParser/Parser/Tokens.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Parser;
 
 /* GENERATED file based on grammar/tokens.y */

--- a/lib/PhpParser/ParserAbstract.php
+++ b/lib/PhpParser/ParserAbstract.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser;
 
 /*
@@ -730,7 +732,7 @@ abstract class ParserAbstract implements Parser
     }
 
     protected function checkNamespace(Namespace_ $node) {
-        if ($node->name && isset(self::$specialNames[strtolower($node->name)])) {
+        if ($node->name && isset(self::$specialNames[strtolower((string) $node->name)])) {
             $this->emitError(new Error(
                 sprintf('Cannot use \'%s\' as namespace name', $node->name),
                 $node->name->getAttributes()
@@ -749,14 +751,14 @@ abstract class ParserAbstract implements Parser
     }
 
     protected function checkClass(Class_ $node, $namePos) {
-        if (null !== $node->name && isset(self::$specialNames[strtolower($node->name)])) {
+        if (null !== $node->name && isset(self::$specialNames[strtolower((string) $node->name)])) {
             $this->emitError(new Error(
                 sprintf('Cannot use \'%s\' as class name as it is reserved', $node->name),
                 $this->getAttributesAt($namePos)
             ));
         }
 
-        if ($node->extends && isset(self::$specialNames[strtolower($node->extends)])) {
+        if ($node->extends && isset(self::$specialNames[strtolower((string) $node->extends)])) {
             $this->emitError(new Error(
                 sprintf('Cannot use \'%s\' as class name as it is reserved', $node->extends),
                 $node->extends->getAttributes()
@@ -764,7 +766,7 @@ abstract class ParserAbstract implements Parser
         }
 
         foreach ($node->implements as $interface) {
-            if (isset(self::$specialNames[strtolower($interface)])) {
+            if (isset(self::$specialNames[strtolower((string) $interface)])) {
                 $this->emitError(new Error(
                     sprintf('Cannot use \'%s\' as interface name as it is reserved', $interface),
                     $interface->getAttributes()
@@ -774,7 +776,7 @@ abstract class ParserAbstract implements Parser
     }
 
     protected function checkInterface(Interface_ $node, $namePos) {
-        if (null !== $node->name && isset(self::$specialNames[strtolower($node->name)])) {
+        if (null !== $node->name && isset(self::$specialNames[strtolower((string) $node->name)])) {
             $this->emitError(new Error(
                 sprintf('Cannot use \'%s\' as class name as it is reserved', $node->name),
                 $this->getAttributesAt($namePos)
@@ -782,7 +784,7 @@ abstract class ParserAbstract implements Parser
         }
 
         foreach ($node->extends as $interface) {
-            if (isset(self::$specialNames[strtolower($interface)])) {
+            if (isset(self::$specialNames[strtolower((string) $interface)])) {
                 $this->emitError(new Error(
                     sprintf('Cannot use \'%s\' as interface name as it is reserved', $interface),
                     $interface->getAttributes()
@@ -793,7 +795,7 @@ abstract class ParserAbstract implements Parser
 
     protected function checkClassMethod(ClassMethod $node, $modifierPos) {
         if ($node->flags & Class_::MODIFIER_STATIC) {
-            switch (strtolower($node->name)) {
+            switch (strtolower((string) $node->name)) {
                 case '__construct':
                     $this->emitError(new Error(
                         sprintf('Constructor %s() cannot be static', $node->name),
@@ -844,7 +846,7 @@ abstract class ParserAbstract implements Parser
     }
 
     protected function checkUseUse(UseUse $node, $namePos) {
-        if ('self' === strtolower($node->alias) || 'parent' === strtolower($node->alias)) {
+        if ('self' === strtolower((string) $node->alias) || 'parent' === strtolower((string) $node->alias)) {
             $this->emitError(new Error(
                 sprintf(
                     'Cannot use %s as %s because \'%2$s\' is a special class name',

--- a/lib/PhpParser/ParserFactory.php
+++ b/lib/PhpParser/ParserFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser;
 
 class ParserFactory {

--- a/lib/PhpParser/PrettyPrinter/Standard.php
+++ b/lib/PhpParser/PrettyPrinter/Standard.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\PrettyPrinter;
 
 use PhpParser\Node;

--- a/lib/PhpParser/PrettyPrinterAbstract.php
+++ b/lib/PhpParser/PrettyPrinterAbstract.php
@@ -509,7 +509,7 @@ abstract class PrettyPrinterAbstract
 
                 if (is_array($subNode) && is_array($origSubNode)) {
                     // Array subnode changed, we might be able to reconstruct it
-                    $fixup = isset($fixupInfo[$subNodeName]) ? $fixupInfo[$subNodeName] : null;
+                    $fixup = $fixupInfo[$subNodeName] ?? null;
                     $listResult = $this->pArray(
                         $subNode, $origSubNode, $pos, $indentAdjustment, $fixup
                     );

--- a/lib/PhpParser/PrettyPrinterAbstract.php
+++ b/lib/PhpParser/PrettyPrinterAbstract.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser;
 
 use PhpParser\Node\Expr;

--- a/lib/bootstrap.php
+++ b/lib/bootstrap.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 if (!class_exists('PhpParser\Autoloader')) {
     require __DIR__ . '/PhpParser/Autoloader.php';
 }

--- a/test/PhpParser/AutoloaderTest.php
+++ b/test/PhpParser/AutoloaderTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser;
 
 /* The autoloader is already active at this point, so we only check effects here. */

--- a/test/PhpParser/Builder/ClassTest.php
+++ b/test/PhpParser/Builder/ClassTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Builder;
 
 use PhpParser\Comment;

--- a/test/PhpParser/Builder/FunctionTest.php
+++ b/test/PhpParser/Builder/FunctionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Builder;
 
 use PhpParser\Comment;

--- a/test/PhpParser/Builder/InterfaceTest.php
+++ b/test/PhpParser/Builder/InterfaceTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Builder;
 
 use PhpParser\Comment;

--- a/test/PhpParser/Builder/MethodTest.php
+++ b/test/PhpParser/Builder/MethodTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Builder;
 
 use PhpParser\Comment;

--- a/test/PhpParser/Builder/NamespaceTest.php
+++ b/test/PhpParser/Builder/NamespaceTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Builder;
 
 use PhpParser\Node;

--- a/test/PhpParser/Builder/ParamTest.php
+++ b/test/PhpParser/Builder/ParamTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Builder;
 
 use PhpParser\Node;

--- a/test/PhpParser/Builder/PropertyTest.php
+++ b/test/PhpParser/Builder/PropertyTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Builder;
 
 use PhpParser\Comment;

--- a/test/PhpParser/Builder/TraitTest.php
+++ b/test/PhpParser/Builder/TraitTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Builder;
 
 use PhpParser\Comment;

--- a/test/PhpParser/Builder/UseTest.php
+++ b/test/PhpParser/Builder/UseTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use PhpParser\Builder;
 use PhpParser\Node\Name;
 use PhpParser\Node\Stmt;

--- a/test/PhpParser/BuilderFactoryTest.php
+++ b/test/PhpParser/BuilderFactoryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser;
 
 use PhpParser\Node\Arg;

--- a/test/PhpParser/CodeParsingTest.php
+++ b/test/PhpParser/CodeParsingTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser;
 
 require_once __DIR__ . '/CodeTestAbstract.php';

--- a/test/PhpParser/CodeTestAbstract.php
+++ b/test/PhpParser/CodeTestAbstract.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser;
 
 use PHPUnit\Framework\TestCase;

--- a/test/PhpParser/CodeTestParser.php
+++ b/test/PhpParser/CodeTestParser.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser;
 
 class CodeTestParser {

--- a/test/PhpParser/CommentTest.php
+++ b/test/PhpParser/CommentTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser;
 
 use PHPUnit\Framework\TestCase;

--- a/test/PhpParser/ErrorHandler/CollectingTest.php
+++ b/test/PhpParser/ErrorHandler/CollectingTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\ErrorHandler;
 
 use PhpParser\Error;

--- a/test/PhpParser/ErrorHandler/ThrowingTest.php
+++ b/test/PhpParser/ErrorHandler/ThrowingTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\ErrorHandler;
 
 use PhpParser\Error;

--- a/test/PhpParser/ErrorTest.php
+++ b/test/PhpParser/ErrorTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser;
 
 use PHPUnit\Framework\TestCase;

--- a/test/PhpParser/Lexer/EmulativeTest.php
+++ b/test/PhpParser/Lexer/EmulativeTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Lexer;
 
 use PhpParser\LexerTest;

--- a/test/PhpParser/LexerTest.php
+++ b/test/PhpParser/LexerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser;
 
 use PhpParser\Parser\Tokens;

--- a/test/PhpParser/NameContextTest.php
+++ b/test/PhpParser/NameContextTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser;
 
 use PhpParser\Node\Name;

--- a/test/PhpParser/Node/NameTest.php
+++ b/test/PhpParser/Node/NameTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node;
 
 use PHPUnit\Framework\TestCase;

--- a/test/PhpParser/Node/Scalar/MagicConstTest.php
+++ b/test/PhpParser/Node/Scalar/MagicConstTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Scalar;
 
 use PHPUnit\Framework\TestCase;

--- a/test/PhpParser/Node/Scalar/StringTest.php
+++ b/test/PhpParser/Node/Scalar/StringTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Scalar;
 
 use PHPUnit\Framework\TestCase;

--- a/test/PhpParser/Node/Stmt/ClassConstTest.php
+++ b/test/PhpParser/Node/Stmt/ClassConstTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Stmt;
 
 use PHPUnit\Framework\TestCase;

--- a/test/PhpParser/Node/Stmt/ClassMethodTest.php
+++ b/test/PhpParser/Node/Stmt/ClassMethodTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Stmt;
 
 use PhpParser\Node\Expr\Variable;

--- a/test/PhpParser/Node/Stmt/ClassTest.php
+++ b/test/PhpParser/Node/Stmt/ClassTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Stmt;
 
 use PHPUnit\Framework\TestCase;

--- a/test/PhpParser/Node/Stmt/InterfaceTest.php
+++ b/test/PhpParser/Node/Stmt/InterfaceTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Stmt;
 
 use PhpParser\Node;

--- a/test/PhpParser/Node/Stmt/PropertyTest.php
+++ b/test/PhpParser/Node/Stmt/PropertyTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Node\Stmt;
 
 use PHPUnit\Framework\TestCase;

--- a/test/PhpParser/NodeAbstractTest.php
+++ b/test/PhpParser/NodeAbstractTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser;
 
 use PHPUnit\Framework\TestCase;

--- a/test/PhpParser/NodeDumperTest.php
+++ b/test/PhpParser/NodeDumperTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser;
 
 use PHPUnit\Framework\TestCase;

--- a/test/PhpParser/NodeFinderTest.php
+++ b/test/PhpParser/NodeFinderTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser;
 
 use PhpParser\Node\Expr;

--- a/test/PhpParser/NodeTraverserTest.php
+++ b/test/PhpParser/NodeTraverserTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser;
 
 use PhpParser\Node\Expr;

--- a/test/PhpParser/NodeVisitor/FindingVisitorTest.php
+++ b/test/PhpParser/NodeVisitor/FindingVisitorTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\NodeVisitor;
 
 use PhpParser\Node;

--- a/test/PhpParser/NodeVisitor/FirstFindingVisitorTest.php
+++ b/test/PhpParser/NodeVisitor/FirstFindingVisitorTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\NodeVisitor;
 
 use PhpParser\Node;

--- a/test/PhpParser/NodeVisitor/NameResolverTest.php
+++ b/test/PhpParser/NodeVisitor/NameResolverTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\NodeVisitor;
 
 use PhpParser;

--- a/test/PhpParser/Parser/MultipleTest.php
+++ b/test/PhpParser/Parser/MultipleTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Parser;
 
 use PhpParser\Error;

--- a/test/PhpParser/Parser/Php5Test.php
+++ b/test/PhpParser/Parser/Php5Test.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Parser;
 
 use PhpParser\Lexer;

--- a/test/PhpParser/Parser/Php7Test.php
+++ b/test/PhpParser/Parser/Php7Test.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser\Parser;
 
 use PhpParser\Lexer;

--- a/test/PhpParser/ParserFactoryTest.php
+++ b/test/PhpParser/ParserFactoryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser;
 
 /* This test is very weak, because PHPUnit's assertEquals assertion is way too slow dealing with the

--- a/test/PhpParser/ParserTest.php
+++ b/test/PhpParser/ParserTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser;
 
 use PhpParser\Node\Expr;

--- a/test/PhpParser/PrettyPrinterTest.php
+++ b/test/PhpParser/PrettyPrinterTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser;
 
 use PhpParser\Node\Expr;
@@ -101,8 +103,8 @@ class PrettyPrinterTest extends CodeTestAbstract
     }
 
     private function parseModeLine($modeLine) {
-        $parts = explode(' ', $modeLine, 2);
-        $version = isset($parts[0]) ? $parts[0] : 'both';
+        $parts = explode(' ', (string) $modeLine, 2);
+        $version = $parts[0] ?? 'both';
         $options = isset($parts[1]) ? json_decode($parts[1], true) : [];
         return [$version, $options];
     }

--- a/test/bootstrap.php
+++ b/test/bootstrap.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser;
 
 require __DIR__ . '/../vendor/autoload.php';

--- a/test/updateTests.php
+++ b/test/updateTests.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpParser;
 
 require __DIR__ . '/bootstrap.php';


### PR DESCRIPTION
I've noticed PHP 7 typehints are already there, so could complete them.

I came across only few `strtolower($node)` => `strtolower((string) $node` issues, all works otherwise.