### PR TITLE
Fix spelling in documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ Version 4.0.0-alpha1 (2017-10-18)
   AST traversal. This facilitates use in other context, such as class names in doc comments.
   Additionally it provides an API for getting the shortest representation of a name.
 * Added `Node::setAttributes()` method.
-* Added `JsonDecoder`. This allows convertion JSON back into an AST.
+* Added `JsonDecoder`. This allows conversion JSON back into an AST.
 * Added `Name` methods `toLowerString()` and `isSpecialClassName()`.
 * Added `Identifier` and `VarLikeIdentifier` nodes, which are used in place of simple strings in
   many places.
@@ -307,7 +307,7 @@ Additionally the following changes were made:
   takes an array of subnodes. Unlike classes/interfaces, traits can only have a `stmts` subnode.
 * The `NodeDumper` now prints class/method/property/constant modifiers, as well as the include and
   use type in a textual representation, instead of only showing the number.
-* All methods on `PrettyPrinter\Standard` are now protected. Previoulsy most of them were public.
+* All methods on `PrettyPrinter\Standard` are now protected. Previously most of them were public.
 
 ### Removed
 
@@ -345,7 +345,7 @@ Version 2.1.0 (2016-04-19)
 * Added `kind` attribute to `Expr\Exit` to distinguish between `exit` and `die`.
 * Added `kind` attribute to `Scalar\LNumber` to distinguish between decimal, binary, octal and
   hexadecimal numbers.
-* Added `kind` attribtue to `Expr\Array` to distinguish between `array()` and `[]`.
+* Added `kind` attribute to `Expr\Array` to distinguish between `array()` and `[]`.
 * Added `kind` attribute to `Scalar\String` and `Scalar\Encapsed` to distinguish between
   single-quoted, double-quoted, heredoc and nowdoc string.
 * Added `docLabel` attribute to `Scalar\String` and `Scalar\Encapsed`, if it is a heredoc or

--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -115,7 +115,7 @@ public function startLexing($code);
 public function startLexing($code, ErrorHandler $errorHandler = null);
 ```
 
-If you use a custom lexer with overriden `startLexing()` method, it needs to be changed to accept
+If you use a custom lexer with overridden `startLexing()` method, it needs to be changed to accept
 the extra parameter. The value should be passed on to the parent method.
 
 #### Error checks in node constructors
@@ -148,7 +148,7 @@ The following methods, arguments or options have been removed:
    namespace into fully qualified names. For example `foo()` in the global namespace resolves to
    `\foo()`. For names where no static resolution is possible, a `namespacedName` attribute is
    added now, containing the namespaced variant of the name.
- * All methods on `PrettyPrinter\Standard` are now protected. Previoulsy most of them were public.
+ * All methods on `PrettyPrinter\Standard` are now protected. Previously most of them were public.
    The pretty printer should only be invoked using the `prettyPrint()`, `prettyPrintFile()` and
    `prettyPrintExpr()` methods.
  * The node dumper now prints numeric values that act as enums/flags in a string representation.

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -55,9 +55,9 @@ Because HHVM does not support PHP 7, HHVM is no longer supported.
   
 ### Miscellaneous
 
-* The indenentation handling in the pretty printer has been changed (this is only relevant if you
+* The indentation handling in the pretty printer has been changed (this is only relevant if you
   extend the pretty printer). Previously indentation was automatic, and parts were excluded using
-  `pNoindent()`. Now no-indent is the default and newlins that require indentation should use
+  `pNoindent()`. Now no-indent is the default and newlines that require indentation should use
   `$this->nl`.
 
 ### Removed functionality

--- a/grammar/README.md
+++ b/grammar/README.md
@@ -11,7 +11,7 @@ What do all those files mean?
 .phpy pseudo language
 =====================
 
-The `.y` file is a normal grammer in `kmyacc` (`yacc`) style, with some transformations
+The `.y` file is a normal grammar in `kmyacc` (`yacc`) style, with some transformations
 applied to it:
 
  * Nodes are created using the syntax `Name[..., ...]`. This is transformed into


### PR DESCRIPTION
Hi
I am busy helping fix spelling in the documentation of popular PHP projects.
Here are some minor fixes