### PR TITLE
Correctly determine Type of Node when PHP-Parser's namespaces are prefixed

### DIFF
--- a/lib/PhpParser/NodeAbstract.php
+++ b/lib/PhpParser/NodeAbstract.php
@@ -21,7 +21,15 @@ abstract class NodeAbstract implements Node, \JsonSerializable
      * @return string Type of the node
      */
     public function getType() : string {
-        return strtr(substr(rtrim(get_class($this), '_'), 15), '\\', '_');
+        $className = rtrim(get_class($this), '_');
+        return strtr(
+            substr(
+                $className,
+                strpos($className, 'PhpParser\Node') + 15
+            ),
+            '\\',
+            '_'
+        );
     }
 
     /**


### PR DESCRIPTION
Hi there,

I'm working on mutation testing framework ([Infection](https://github.com/infection/infection/)) that is distributed as a PHAR. One of its goal is to run target project's test suite against mutated code. Since we use reflection and load project's autoloader, we want to avoid potential conflicts between vendor files of Infection itself and the target project.

To avoid this issue, there is a project called [PHP-Scoper](https://github.com/humbug/php-scoper). What it does is it prefixes all the namespaces of the library (including vendor folder) with some character(s), for example namespace `Infection\Mutator\PublicVisibility` is transformed to `ScoperAbc123\Infection\Mutant\PublicVisibility`. 

But since it also prefixes vendor folder, PHP-Parser's classes are prefixed as well and `NodeAbstract::getType()` after this prefixing works incorrectly.

There is a hardcoded number `15` which means to remove `'PhpParser\Node'` (length=15) substring from the FQCN.

Code:

```php
// PHPParser\Node\Stmt\Declare_ -> Stmt_Declare

return strtr(substr(rtrim(get_class($this), '_'), 15), '\\', '_');
```

What I suggest is a little bit more dynamic solution, to correctly extract class name (type) from the **prefixed** FQCN:

`ScoperAbc123\PHPParser\Node\Stmt\Declare_` -> `Stmt_Declare`