### PR TITLE
Avoid empty first part for global namespace in NameResolver::resolveC…

### DIFF
--- a/lib/PhpParser/NodeVisitor/NameResolver.php
+++ b/lib/PhpParser/NodeVisitor/NameResolver.php
@@ -215,7 +215,13 @@ class NameResolver extends NodeVisitorAbstract
             return FullyQualified::concat($alias, $name->slice(1), $name->getAttributes());
         }
 
-        // if no alias exists prepend current namespace
+        $isGlobalNamespace = $this->namespace !== null && $this->namespace->toString() === '';
+        if ($isGlobalNamespace) {
+            return new FullyQualified($name, $name->getAttributes());
+        }
+
+        // if no alias exists and it is not global namespace prepend current namespace
+
         return FullyQualified::concat($this->namespace, $name, $name->getAttributes());
     }
 


### PR DESCRIPTION
…lassName

During investigate https://github.com/goaop/parser-reflection/issues/80 and https://github.com/goaop/parser-reflection/pull/83 I found that root of issue is in `Name::$parts[0] === ''` in global namespace which append by NameResolver::resolveClassName during resolve class names using in global namespace like fetch class const.