### PR TITLE
Refactoring tests

### DIFF
--- a/test/PhpParser/ErrorTest.php
+++ b/test/PhpParser/ErrorTest.php
@@ -49,7 +49,7 @@ class ErrorTest extends TestCase
             'endFilePos' => $endPos,
         ]);
 
-        $this->assertSame(true, $error->hasColumnInfo());
+        $this->assertTrue($error->hasColumnInfo());
         $this->assertSame($startColumn, $error->getStartColumn($code));
         $this->assertSame($endColumn, $error->getEndColumn($code));
 
@@ -79,7 +79,7 @@ class ErrorTest extends TestCase
     public function testNoColumnInfo() {
         $error = new Error('Some error', 3);
 
-        $this->assertSame(false, $error->hasColumnInfo());
+        $this->assertFalse($error->hasColumnInfo());
         try {
             $error->getStartColumn('');
             $this->fail('Expected RuntimeException');

--- a/test/PhpParser/LexerTest.php
+++ b/test/PhpParser/LexerTest.php
@@ -27,7 +27,7 @@ class LexerTest extends TestCase
         $lexer->startLexing($code, $errorHandler);
         $errors = $errorHandler->getErrors();
 
-        $this->assertSame(count($messages), count($errors));
+        $this->assertCount(count($messages), $errors);
         for ($i = 0; $i < count($messages); $i++) {
             $this->assertSame($messages[$i], $errors[$i]->getMessageWithColumnInfo($code));
         }

--- a/test/PhpParser/NodeAbstractTest.php
+++ b/test/PhpParser/NodeAbstractTest.php
@@ -64,9 +64,9 @@ class NodeAbstractTest extends TestCase
         $this->assertSame('/** doc comment */', $node->getDocComment()->getText());
         $this->assertSame('value1', $node->subNode1);
         $this->assertSame('value2', $node->subNode2);
-        $this->assertTrue(isset($node->subNode1));
-        $this->assertTrue(isset($node->subNode2));
-        $this->assertFalse(isset($node->subNode3));
+        $this->assertObjectHasAttribute('subNode1', $node);
+        $this->assertObjectHasAttribute('subNode2', $node);
+        $this->assertObjectNotHasAttribute('subNode3', $node);
         $this->assertSame($attributes, $node->getAttributes());
         $this->assertSame($attributes['comments'], $node->getComments());
 
@@ -126,7 +126,7 @@ class NodeAbstractTest extends TestCase
 
         // removal
         unset($node->subNode);
-        $this->assertFalse(isset($node->subNode));
+        $this->assertObjectNotHasAttribute('subNode', $node);
     }
 
     /**

--- a/test/PhpParser/NodeFinderTest.php
+++ b/test/PhpParser/NodeFinderTest.php
@@ -47,7 +47,7 @@ class NodeFinderTest extends TestCase
         $this->assertSame($vars[0], $finder->findFirst($stmts[0], $varFilter));
 
         $noneFilter = function () { return false; };
-        $this->assertSame(null, $finder->findFirst($stmts, $noneFilter));
+        $this->assertNull($finder->findFirst($stmts, $noneFilter));
     }
 
     public function testFindFirstInstanceOf() {
@@ -55,6 +55,6 @@ class NodeFinderTest extends TestCase
         list($stmts, $vars) = $this->getStmtsAndVars();
         $this->assertSame($vars[0], $finder->findFirstInstanceOf($stmts, Expr\Variable::class));
         $this->assertSame($vars[0], $finder->findFirstInstanceOf($stmts[0], Expr\Variable::class));
-        $this->assertSame(null, $finder->findFirstInstanceOf($stmts, Expr\BinaryOp\Mul::class));
+        $this->assertNull($finder->findFirstInstanceOf($stmts, Expr\BinaryOp\Mul::class));
     }
 }


### PR DESCRIPTION
I've refactored some tests, using:
- `assertCount` instead of `count` function;
- `assertTrue` instead of strict comparison with `true` keyword;
- `assertFalse` instead of strict comparison with `false` keyword;
- `assertNull` instead of strict comparison with `null` keyword;
- `assertObjectHasAttribute` and `assertObjectNotHasAttribute` instead of `isset` function.