### PR TITLE
Add public visibility to getType method

### DIFF
--- a/lib/PhpParser/Node/Arg.php
+++ b/lib/PhpParser/Node/Arg.php
@@ -32,7 +32,7 @@ class Arg extends NodeAbstract
         return ['value', 'byRef', 'unpack'];
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Arg';
     }
 }

--- a/lib/PhpParser/Node/Const_.php
+++ b/lib/PhpParser/Node/Const_.php
@@ -31,7 +31,7 @@ class Const_ extends NodeAbstract
         return ['name', 'value'];
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Const';
     }
 }

--- a/lib/PhpParser/Node/Expr/ArrayDimFetch.php
+++ b/lib/PhpParser/Node/Expr/ArrayDimFetch.php
@@ -28,7 +28,7 @@ class ArrayDimFetch extends Expr
         return ['var', 'dim'];
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Expr_ArrayDimFetch';
     }
 }

--- a/lib/PhpParser/Node/Expr/ArrayItem.php
+++ b/lib/PhpParser/Node/Expr/ArrayItem.php
@@ -32,7 +32,7 @@ class ArrayItem extends Expr
         return ['key', 'value', 'byRef'];
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Expr_ArrayItem';
     }
 }

--- a/lib/PhpParser/Node/Expr/Array_.php
+++ b/lib/PhpParser/Node/Expr/Array_.php
@@ -28,7 +28,7 @@ class Array_ extends Expr
         return ['items'];
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Expr_Array';
     }
 }

--- a/lib/PhpParser/Node/Expr/Assign.php
+++ b/lib/PhpParser/Node/Expr/Assign.php
@@ -28,7 +28,7 @@ class Assign extends Expr
         return ['var', 'expr'];
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Expr_Assign';
     }
 }

--- a/lib/PhpParser/Node/Expr/AssignOp/BitwiseAnd.php
+++ b/lib/PhpParser/Node/Expr/AssignOp/BitwiseAnd.php
@@ -6,7 +6,7 @@ use PhpParser\Node\Expr\AssignOp;
 
 class BitwiseAnd extends AssignOp
 {
-    function getType() : string {
+    public function getType() : string {
         return 'Expr_AssignOp_BitwiseAnd';
     }
 }

--- a/lib/PhpParser/Node/Expr/AssignOp/BitwiseOr.php
+++ b/lib/PhpParser/Node/Expr/AssignOp/BitwiseOr.php
@@ -6,7 +6,7 @@ use PhpParser\Node\Expr\AssignOp;
 
 class BitwiseOr extends AssignOp
 {
-    function getType() : string {
+    public function getType() : string {
         return 'Expr_AssignOp_BitwiseOr';
     }
 }

--- a/lib/PhpParser/Node/Expr/AssignOp/BitwiseXor.php
+++ b/lib/PhpParser/Node/Expr/AssignOp/BitwiseXor.php
@@ -6,7 +6,7 @@ use PhpParser\Node\Expr\AssignOp;
 
 class BitwiseXor extends AssignOp
 {
-    function getType() : string {
+    public function getType() : string {
         return 'Expr_AssignOp_BitwiseXor';
     }
 }

--- a/lib/PhpParser/Node/Expr/AssignOp/Concat.php
+++ b/lib/PhpParser/Node/Expr/AssignOp/Concat.php
@@ -6,7 +6,7 @@ use PhpParser\Node\Expr\AssignOp;
 
 class Concat extends AssignOp
 {
-    function getType() : string {
+    public function getType() : string {
         return 'Expr_AssignOp_Concat';
     }
 }

--- a/lib/PhpParser/Node/Expr/AssignOp/Div.php
+++ b/lib/PhpParser/Node/Expr/AssignOp/Div.php
@@ -6,7 +6,7 @@ use PhpParser\Node\Expr\AssignOp;
 
 class Div extends AssignOp
 {
-    function getType() : string {
+    public function getType() : string {
         return 'Expr_AssignOp_Div';
     }
 }

--- a/lib/PhpParser/Node/Expr/AssignOp/Minus.php
+++ b/lib/PhpParser/Node/Expr/AssignOp/Minus.php
@@ -6,7 +6,7 @@ use PhpParser\Node\Expr\AssignOp;
 
 class Minus extends AssignOp
 {
-    function getType() : string {
+    public function getType() : string {
         return 'Expr_AssignOp_Minus';
     }
 }

--- a/lib/PhpParser/Node/Expr/AssignOp/Mod.php
+++ b/lib/PhpParser/Node/Expr/AssignOp/Mod.php
@@ -6,7 +6,7 @@ use PhpParser\Node\Expr\AssignOp;
 
 class Mod extends AssignOp
 {
-    function getType() : string {
+    public function getType() : string {
         return 'Expr_AssignOp_Mod';
     }
 }

--- a/lib/PhpParser/Node/Expr/AssignOp/Mul.php
+++ b/lib/PhpParser/Node/Expr/AssignOp/Mul.php
@@ -6,7 +6,7 @@ use PhpParser\Node\Expr\AssignOp;
 
 class Mul extends AssignOp
 {
-    function getType() : string {
+    public function getType() : string {
         return 'Expr_AssignOp_Mul';
     }
 }

--- a/lib/PhpParser/Node/Expr/AssignOp/Plus.php
+++ b/lib/PhpParser/Node/Expr/AssignOp/Plus.php
@@ -6,7 +6,7 @@ use PhpParser\Node\Expr\AssignOp;
 
 class Plus extends AssignOp
 {
-    function getType() : string {
+    public function getType() : string {
         return 'Expr_AssignOp_Plus';
     }
 }

--- a/lib/PhpParser/Node/Expr/AssignOp/Pow.php
+++ b/lib/PhpParser/Node/Expr/AssignOp/Pow.php
@@ -6,7 +6,7 @@ use PhpParser\Node\Expr\AssignOp;
 
 class Pow extends AssignOp
 {
-    function getType() : string {
+    public function getType() : string {
         return 'Expr_AssignOp_Pow';
     }
 }

--- a/lib/PhpParser/Node/Expr/AssignOp/ShiftLeft.php
+++ b/lib/PhpParser/Node/Expr/AssignOp/ShiftLeft.php
@@ -6,7 +6,7 @@ use PhpParser\Node\Expr\AssignOp;
 
 class ShiftLeft extends AssignOp
 {
-    function getType() : string {
+    public function getType() : string {
         return 'Expr_AssignOp_ShiftLeft';
     }
 }

--- a/lib/PhpParser/Node/Expr/AssignOp/ShiftRight.php
+++ b/lib/PhpParser/Node/Expr/AssignOp/ShiftRight.php
@@ -6,7 +6,7 @@ use PhpParser\Node\Expr\AssignOp;
 
 class ShiftRight extends AssignOp
 {
-    function getType() : string {
+    public function getType() : string {
         return 'Expr_AssignOp_ShiftRight';
     }
 }

--- a/lib/PhpParser/Node/Expr/AssignRef.php
+++ b/lib/PhpParser/Node/Expr/AssignRef.php
@@ -28,7 +28,7 @@ class AssignRef extends Expr
         return ['var', 'expr'];
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Expr_AssignRef';
     }
 }

--- a/lib/PhpParser/Node/Expr/BinaryOp/BitwiseAnd.php
+++ b/lib/PhpParser/Node/Expr/BinaryOp/BitwiseAnd.php
@@ -10,7 +10,7 @@ class BitwiseAnd extends BinaryOp
         return '&';
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Expr_BinaryOp_BitwiseAnd';
     }
 }

--- a/lib/PhpParser/Node/Expr/BinaryOp/BitwiseOr.php
+++ b/lib/PhpParser/Node/Expr/BinaryOp/BitwiseOr.php
@@ -10,7 +10,7 @@ class BitwiseOr extends BinaryOp
         return '|';
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Expr_BinaryOp_BitwiseOr';
     }
 }

--- a/lib/PhpParser/Node/Expr/BinaryOp/BitwiseXor.php
+++ b/lib/PhpParser/Node/Expr/BinaryOp/BitwiseXor.php
@@ -10,7 +10,7 @@ class BitwiseXor extends BinaryOp
         return '^';
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Expr_BinaryOp_BitwiseXor';
     }
 }

--- a/lib/PhpParser/Node/Expr/BinaryOp/BooleanAnd.php
+++ b/lib/PhpParser/Node/Expr/BinaryOp/BooleanAnd.php
@@ -10,7 +10,7 @@ class BooleanAnd extends BinaryOp
         return '&&';
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Expr_BinaryOp_BooleanAnd';
     }
 }

--- a/lib/PhpParser/Node/Expr/BinaryOp/BooleanOr.php
+++ b/lib/PhpParser/Node/Expr/BinaryOp/BooleanOr.php
@@ -10,7 +10,7 @@ class BooleanOr extends BinaryOp
         return '||';
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Expr_BinaryOp_BooleanOr';
     }
 }

--- a/lib/PhpParser/Node/Expr/BinaryOp/Coalesce.php
+++ b/lib/PhpParser/Node/Expr/BinaryOp/Coalesce.php
@@ -10,7 +10,7 @@ class Coalesce extends BinaryOp
         return '??';
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Expr_BinaryOp_Coalesce';
     }
 }

--- a/lib/PhpParser/Node/Expr/BinaryOp/Concat.php
+++ b/lib/PhpParser/Node/Expr/BinaryOp/Concat.php
@@ -10,7 +10,7 @@ class Concat extends BinaryOp
         return '.';
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Expr_BinaryOp_Concat';
     }
 }

--- a/lib/PhpParser/Node/Expr/BinaryOp/Div.php
+++ b/lib/PhpParser/Node/Expr/BinaryOp/Div.php
@@ -10,7 +10,7 @@ class Div extends BinaryOp
         return '/';
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Expr_BinaryOp_Div';
     }
 }

--- a/lib/PhpParser/Node/Expr/BinaryOp/Equal.php
+++ b/lib/PhpParser/Node/Expr/BinaryOp/Equal.php
@@ -10,7 +10,7 @@ class Equal extends BinaryOp
         return '==';
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Expr_BinaryOp_Equal';
     }
 }

--- a/lib/PhpParser/Node/Expr/BinaryOp/Greater.php
+++ b/lib/PhpParser/Node/Expr/BinaryOp/Greater.php
@@ -10,7 +10,7 @@ class Greater extends BinaryOp
         return '>';
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Expr_BinaryOp_Greater';
     }
 }

--- a/lib/PhpParser/Node/Expr/BinaryOp/GreaterOrEqual.php
+++ b/lib/PhpParser/Node/Expr/BinaryOp/GreaterOrEqual.php
@@ -10,7 +10,7 @@ class GreaterOrEqual extends BinaryOp
         return '>=';
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Expr_BinaryOp_GreaterOrEqual';
     }
 }

--- a/lib/PhpParser/Node/Expr/BinaryOp/Identical.php
+++ b/lib/PhpParser/Node/Expr/BinaryOp/Identical.php
@@ -10,7 +10,7 @@ class Identical extends BinaryOp
         return '===';
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Expr_BinaryOp_Identical';
     }
 }

--- a/lib/PhpParser/Node/Expr/BinaryOp/LogicalAnd.php
+++ b/lib/PhpParser/Node/Expr/BinaryOp/LogicalAnd.php
@@ -10,7 +10,7 @@ class LogicalAnd extends BinaryOp
         return 'and';
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Expr_BinaryOp_LogicalAnd';
     }
 }

--- a/lib/PhpParser/Node/Expr/BinaryOp/LogicalOr.php
+++ b/lib/PhpParser/Node/Expr/BinaryOp/LogicalOr.php
@@ -10,7 +10,7 @@ class LogicalOr extends BinaryOp
         return 'or';
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Expr_BinaryOp_LogicalOr';
     }
 }

--- a/lib/PhpParser/Node/Expr/BinaryOp/LogicalXor.php
+++ b/lib/PhpParser/Node/Expr/BinaryOp/LogicalXor.php
@@ -10,7 +10,7 @@ class LogicalXor extends BinaryOp
         return 'xor';
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Expr_BinaryOp_LogicalXor';
     }
 }

--- a/lib/PhpParser/Node/Expr/BinaryOp/Minus.php
+++ b/lib/PhpParser/Node/Expr/BinaryOp/Minus.php
@@ -10,7 +10,7 @@ class Minus extends BinaryOp
         return '-';
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Expr_BinaryOp_Minus';
     }
 }

--- a/lib/PhpParser/Node/Expr/BinaryOp/Mod.php
+++ b/lib/PhpParser/Node/Expr/BinaryOp/Mod.php
@@ -10,7 +10,7 @@ class Mod extends BinaryOp
         return '%';
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Expr_BinaryOp_Mod';
     }
 }

--- a/lib/PhpParser/Node/Expr/BinaryOp/Mul.php
+++ b/lib/PhpParser/Node/Expr/BinaryOp/Mul.php
@@ -10,7 +10,7 @@ class Mul extends BinaryOp
         return '*';
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Expr_BinaryOp_Mul';
     }
 }

--- a/lib/PhpParser/Node/Expr/BinaryOp/NotEqual.php
+++ b/lib/PhpParser/Node/Expr/BinaryOp/NotEqual.php
@@ -10,7 +10,7 @@ class NotEqual extends BinaryOp
         return '!=';
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Expr_BinaryOp_NotEqual';
     }
 }

--- a/lib/PhpParser/Node/Expr/BinaryOp/NotIdentical.php
+++ b/lib/PhpParser/Node/Expr/BinaryOp/NotIdentical.php
@@ -10,7 +10,7 @@ class NotIdentical extends BinaryOp
         return '!==';
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Expr_BinaryOp_NotIdentical';
     }
 }

--- a/lib/PhpParser/Node/Expr/BinaryOp/Plus.php
+++ b/lib/PhpParser/Node/Expr/BinaryOp/Plus.php
@@ -10,7 +10,7 @@ class Plus extends BinaryOp
         return '+';
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Expr_BinaryOp_Plus';
     }
 }

--- a/lib/PhpParser/Node/Expr/BinaryOp/Pow.php
+++ b/lib/PhpParser/Node/Expr/BinaryOp/Pow.php
@@ -10,7 +10,7 @@ class Pow extends BinaryOp
         return '**';
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Expr_BinaryOp_Pow';
     }
 }

--- a/lib/PhpParser/Node/Expr/BinaryOp/ShiftLeft.php
+++ b/lib/PhpParser/Node/Expr/BinaryOp/ShiftLeft.php
@@ -10,7 +10,7 @@ class ShiftLeft extends BinaryOp
         return '<<';
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Expr_BinaryOp_ShiftLeft';
     }
 }

--- a/lib/PhpParser/Node/Expr/BinaryOp/ShiftRight.php
+++ b/lib/PhpParser/Node/Expr/BinaryOp/ShiftRight.php
@@ -10,7 +10,7 @@ class ShiftRight extends BinaryOp
         return '>>';
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Expr_BinaryOp_ShiftRight';
     }
 }

--- a/lib/PhpParser/Node/Expr/BinaryOp/Smaller.php
+++ b/lib/PhpParser/Node/Expr/BinaryOp/Smaller.php
@@ -10,7 +10,7 @@ class Smaller extends BinaryOp
         return '<';
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Expr_BinaryOp_Smaller';
     }
 }

--- a/lib/PhpParser/Node/Expr/BinaryOp/SmallerOrEqual.php
+++ b/lib/PhpParser/Node/Expr/BinaryOp/SmallerOrEqual.php
@@ -10,7 +10,7 @@ class SmallerOrEqual extends BinaryOp
         return '<=';
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Expr_BinaryOp_SmallerOrEqual';
     }
 }

--- a/lib/PhpParser/Node/Expr/BinaryOp/Spaceship.php
+++ b/lib/PhpParser/Node/Expr/BinaryOp/Spaceship.php
@@ -10,7 +10,7 @@ class Spaceship extends BinaryOp
         return '<=>';
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Expr_BinaryOp_Spaceship';
     }
 }

--- a/lib/PhpParser/Node/Expr/BitwiseNot.php
+++ b/lib/PhpParser/Node/Expr/BitwiseNot.php
@@ -24,7 +24,7 @@ class BitwiseNot extends Expr
         return ['expr'];
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Expr_BitwiseNot';
     }
 }

--- a/lib/PhpParser/Node/Expr/BooleanNot.php
+++ b/lib/PhpParser/Node/Expr/BooleanNot.php
@@ -24,7 +24,7 @@ class BooleanNot extends Expr
         return ['expr'];
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Expr_BooleanNot';
     }
 }

--- a/lib/PhpParser/Node/Expr/Cast/Array_.php
+++ b/lib/PhpParser/Node/Expr/Cast/Array_.php
@@ -6,7 +6,7 @@ use PhpParser\Node\Expr\Cast;
 
 class Array_ extends Cast
 {
-    function getType() : string {
+    public function getType() : string {
         return 'Expr_Cast_Array';
     }
 }

--- a/lib/PhpParser/Node/Expr/Cast/Bool_.php
+++ b/lib/PhpParser/Node/Expr/Cast/Bool_.php
@@ -6,7 +6,7 @@ use PhpParser\Node\Expr\Cast;
 
 class Bool_ extends Cast
 {
-    function getType() : string {
+    public function getType() : string {
         return 'Expr_Cast_Bool';
     }
 }

--- a/lib/PhpParser/Node/Expr/Cast/Double.php
+++ b/lib/PhpParser/Node/Expr/Cast/Double.php
@@ -6,7 +6,7 @@ use PhpParser\Node\Expr\Cast;
 
 class Double extends Cast
 {
-    function getType() : string {
+    public function getType() : string {
         return 'Expr_Cast_Double';
     }
 }

--- a/lib/PhpParser/Node/Expr/Cast/Int_.php
+++ b/lib/PhpParser/Node/Expr/Cast/Int_.php
@@ -6,7 +6,7 @@ use PhpParser\Node\Expr\Cast;
 
 class Int_ extends Cast
 {
-    function getType() : string {
+    public function getType() : string {
         return 'Expr_Cast_Int';
     }
 }

--- a/lib/PhpParser/Node/Expr/Cast/Object_.php
+++ b/lib/PhpParser/Node/Expr/Cast/Object_.php
@@ -6,7 +6,7 @@ use PhpParser\Node\Expr\Cast;
 
 class Object_ extends Cast
 {
-    function getType() : string {
+    public function getType() : string {
         return 'Expr_Cast_Object';
     }
 }

--- a/lib/PhpParser/Node/Expr/Cast/String_.php
+++ b/lib/PhpParser/Node/Expr/Cast/String_.php
@@ -6,7 +6,7 @@ use PhpParser\Node\Expr\Cast;
 
 class String_ extends Cast
 {
-    function getType() : string {
+    public function getType() : string {
         return 'Expr_Cast_String';
     }
 }

--- a/lib/PhpParser/Node/Expr/Cast/Unset_.php
+++ b/lib/PhpParser/Node/Expr/Cast/Unset_.php
@@ -6,7 +6,7 @@ use PhpParser\Node\Expr\Cast;
 
 class Unset_ extends Cast
 {
-    function getType() : string {
+    public function getType() : string {
         return 'Expr_Cast_Unset';
     }
 }

--- a/lib/PhpParser/Node/Expr/ClassConstFetch.php
+++ b/lib/PhpParser/Node/Expr/ClassConstFetch.php
@@ -30,7 +30,7 @@ class ClassConstFetch extends Expr
         return ['class', 'name'];
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Expr_ClassConstFetch';
     }
 }

--- a/lib/PhpParser/Node/Expr/Clone_.php
+++ b/lib/PhpParser/Node/Expr/Clone_.php
@@ -24,7 +24,7 @@ class Clone_ extends Expr
         return ['expr'];
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Expr_Clone';
     }
 }

--- a/lib/PhpParser/Node/Expr/Closure.php
+++ b/lib/PhpParser/Node/Expr/Closure.php
@@ -65,7 +65,7 @@ class Closure extends Expr implements FunctionLike
         return $this->stmts;
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Expr_Closure';
     }
 }

--- a/lib/PhpParser/Node/Expr/ClosureUse.php
+++ b/lib/PhpParser/Node/Expr/ClosureUse.php
@@ -28,7 +28,7 @@ class ClosureUse extends Expr
         return ['var', 'byRef'];
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Expr_ClosureUse';
     }
 }

--- a/lib/PhpParser/Node/Expr/ConstFetch.php
+++ b/lib/PhpParser/Node/Expr/ConstFetch.php
@@ -25,7 +25,7 @@ class ConstFetch extends Expr
         return ['name'];
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Expr_ConstFetch';
     }
 }

--- a/lib/PhpParser/Node/Expr/Empty_.php
+++ b/lib/PhpParser/Node/Expr/Empty_.php
@@ -24,7 +24,7 @@ class Empty_ extends Expr
         return ['expr'];
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Expr_Empty';
     }
 }

--- a/lib/PhpParser/Node/Expr/Error.php
+++ b/lib/PhpParser/Node/Expr/Error.php
@@ -25,7 +25,7 @@ class Error extends Expr
         return [];
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Expr_Error';
     }
 }

--- a/lib/PhpParser/Node/Expr/ErrorSuppress.php
+++ b/lib/PhpParser/Node/Expr/ErrorSuppress.php
@@ -24,7 +24,7 @@ class ErrorSuppress extends Expr
         return ['expr'];
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Expr_ErrorSuppress';
     }
 }

--- a/lib/PhpParser/Node/Expr/Eval_.php
+++ b/lib/PhpParser/Node/Expr/Eval_.php
@@ -24,7 +24,7 @@ class Eval_ extends Expr
         return ['expr'];
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Expr_Eval';
     }
 }

--- a/lib/PhpParser/Node/Expr/Exit_.php
+++ b/lib/PhpParser/Node/Expr/Exit_.php
@@ -28,7 +28,7 @@ class Exit_ extends Expr
         return ['expr'];
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Expr_Exit';
     }
 }

--- a/lib/PhpParser/Node/Expr/FuncCall.php
+++ b/lib/PhpParser/Node/Expr/FuncCall.php
@@ -29,7 +29,7 @@ class FuncCall extends Expr
         return ['name', 'args'];
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Expr_FuncCall';
     }
 }

--- a/lib/PhpParser/Node/Expr/Include_.php
+++ b/lib/PhpParser/Node/Expr/Include_.php
@@ -33,7 +33,7 @@ class Include_ extends Expr
         return ['expr', 'type'];
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Expr_Include';
     }
 }

--- a/lib/PhpParser/Node/Expr/Instanceof_.php
+++ b/lib/PhpParser/Node/Expr/Instanceof_.php
@@ -29,7 +29,7 @@ class Instanceof_ extends Expr
         return ['expr', 'class'];
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Expr_Instanceof';
     }
 }

--- a/lib/PhpParser/Node/Expr/Isset_.php
+++ b/lib/PhpParser/Node/Expr/Isset_.php
@@ -24,7 +24,7 @@ class Isset_ extends Expr
         return ['vars'];
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Expr_Isset';
     }
 }

--- a/lib/PhpParser/Node/Expr/List_.php
+++ b/lib/PhpParser/Node/Expr/List_.php
@@ -24,7 +24,7 @@ class List_ extends Expr
         return ['items'];
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Expr_List';
     }
 }

--- a/lib/PhpParser/Node/Expr/MethodCall.php
+++ b/lib/PhpParser/Node/Expr/MethodCall.php
@@ -34,7 +34,7 @@ class MethodCall extends Expr
         return ['var', 'name', 'args'];
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Expr_MethodCall';
     }
 }

--- a/lib/PhpParser/Node/Expr/New_.php
+++ b/lib/PhpParser/Node/Expr/New_.php
@@ -29,7 +29,7 @@ class New_ extends Expr
         return ['class', 'args'];
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Expr_New';
     }
 }

--- a/lib/PhpParser/Node/Expr/PostDec.php
+++ b/lib/PhpParser/Node/Expr/PostDec.php
@@ -24,7 +24,7 @@ class PostDec extends Expr
         return ['var'];
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Expr_PostDec';
     }
 }

--- a/lib/PhpParser/Node/Expr/PostInc.php
+++ b/lib/PhpParser/Node/Expr/PostInc.php
@@ -24,7 +24,7 @@ class PostInc extends Expr
         return ['var'];
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Expr_PostInc';
     }
 }

--- a/lib/PhpParser/Node/Expr/PreDec.php
+++ b/lib/PhpParser/Node/Expr/PreDec.php
@@ -24,7 +24,7 @@ class PreDec extends Expr
         return ['var'];
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Expr_PreDec';
     }
 }

--- a/lib/PhpParser/Node/Expr/PreInc.php
+++ b/lib/PhpParser/Node/Expr/PreInc.php
@@ -24,7 +24,7 @@ class PreInc extends Expr
         return ['var'];
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Expr_PreInc';
     }
 }

--- a/lib/PhpParser/Node/Expr/Print_.php
+++ b/lib/PhpParser/Node/Expr/Print_.php
@@ -24,7 +24,7 @@ class Print_ extends Expr
         return ['expr'];
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Expr_Print';
     }
 }

--- a/lib/PhpParser/Node/Expr/PropertyFetch.php
+++ b/lib/PhpParser/Node/Expr/PropertyFetch.php
@@ -29,7 +29,7 @@ class PropertyFetch extends Expr
         return ['var', 'name'];
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Expr_PropertyFetch';
     }
 }

--- a/lib/PhpParser/Node/Expr/ShellExec.php
+++ b/lib/PhpParser/Node/Expr/ShellExec.php
@@ -24,7 +24,7 @@ class ShellExec extends Expr
         return ['parts'];
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Expr_ShellExec';
     }
 }

--- a/lib/PhpParser/Node/Expr/StaticCall.php
+++ b/lib/PhpParser/Node/Expr/StaticCall.php
@@ -34,7 +34,7 @@ class StaticCall extends Expr
         return ['class', 'name', 'args'];
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Expr_StaticCall';
     }
 }

--- a/lib/PhpParser/Node/Expr/StaticPropertyFetch.php
+++ b/lib/PhpParser/Node/Expr/StaticPropertyFetch.php
@@ -30,7 +30,7 @@ class StaticPropertyFetch extends Expr
         return ['class', 'name'];
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Expr_StaticPropertyFetch';
     }
 }

--- a/lib/PhpParser/Node/Expr/Ternary.php
+++ b/lib/PhpParser/Node/Expr/Ternary.php
@@ -32,7 +32,7 @@ class Ternary extends Expr
         return ['cond', 'if', 'else'];
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Expr_Ternary';
     }
 }

--- a/lib/PhpParser/Node/Expr/UnaryMinus.php
+++ b/lib/PhpParser/Node/Expr/UnaryMinus.php
@@ -24,7 +24,7 @@ class UnaryMinus extends Expr
         return ['expr'];
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Expr_UnaryMinus';
     }
 }

--- a/lib/PhpParser/Node/Expr/UnaryPlus.php
+++ b/lib/PhpParser/Node/Expr/UnaryPlus.php
@@ -24,7 +24,7 @@ class UnaryPlus extends Expr
         return ['expr'];
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Expr_UnaryPlus';
     }
 }

--- a/lib/PhpParser/Node/Expr/Variable.php
+++ b/lib/PhpParser/Node/Expr/Variable.php
@@ -24,7 +24,7 @@ class Variable extends Expr
         return ['name'];
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Expr_Variable';
     }
 }

--- a/lib/PhpParser/Node/Expr/YieldFrom.php
+++ b/lib/PhpParser/Node/Expr/YieldFrom.php
@@ -24,7 +24,7 @@ class YieldFrom extends Expr
         return ['expr'];
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Expr_YieldFrom';
     }
 }

--- a/lib/PhpParser/Node/Expr/Yield_.php
+++ b/lib/PhpParser/Node/Expr/Yield_.php
@@ -28,7 +28,7 @@ class Yield_ extends Expr
         return ['key', 'value'];
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Expr_Yield';
     }
 }

--- a/lib/PhpParser/Node/Identifier.php
+++ b/lib/PhpParser/Node/Identifier.php
@@ -69,7 +69,7 @@ class Identifier extends NodeAbstract
         return $this->name;
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Identifier';
     }
 }

--- a/lib/PhpParser/Node/Name.php
+++ b/lib/PhpParser/Node/Name.php
@@ -238,7 +238,7 @@ class Name extends NodeAbstract
         );
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Name';
     }
 }

--- a/lib/PhpParser/Node/Name/FullyQualified.php
+++ b/lib/PhpParser/Node/Name/FullyQualified.php
@@ -44,7 +44,7 @@ class FullyQualified extends \PhpParser\Node\Name
         return '\\' . $this->toString();
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Name_FullyQualified';
     }
 }

--- a/lib/PhpParser/Node/Name/Relative.php
+++ b/lib/PhpParser/Node/Name/Relative.php
@@ -44,7 +44,7 @@ class Relative extends \PhpParser\Node\Name
         return 'namespace\\' . $this->toString();
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Name_Relative';
     }
 }

--- a/lib/PhpParser/Node/NullableType.php
+++ b/lib/PhpParser/Node/NullableType.php
@@ -24,7 +24,7 @@ class NullableType extends NodeAbstract
         return ['type'];
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'NullableType';
     }
 }

--- a/lib/PhpParser/Node/Param.php
+++ b/lib/PhpParser/Node/Param.php
@@ -43,7 +43,7 @@ class Param extends NodeAbstract
         return ['type', 'byRef', 'variadic', 'var', 'default'];
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Param';
     }
 }

--- a/lib/PhpParser/Node/Scalar/DNumber.php
+++ b/lib/PhpParser/Node/Scalar/DNumber.php
@@ -62,7 +62,7 @@ class DNumber extends Scalar
         return (float) $str;
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Scalar_DNumber';
     }
 }

--- a/lib/PhpParser/Node/Scalar/Encapsed.php
+++ b/lib/PhpParser/Node/Scalar/Encapsed.php
@@ -25,7 +25,7 @@ class Encapsed extends Scalar
         return ['parts'];
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Scalar_Encapsed';
     }
 }

--- a/lib/PhpParser/Node/Scalar/EncapsedStringPart.php
+++ b/lib/PhpParser/Node/Scalar/EncapsedStringPart.php
@@ -24,7 +24,7 @@ class EncapsedStringPart extends Scalar
         return ['value'];
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Scalar_EncapsedStringPart';
     }
 }

--- a/lib/PhpParser/Node/Scalar/LNumber.php
+++ b/lib/PhpParser/Node/Scalar/LNumber.php
@@ -65,7 +65,7 @@ class LNumber extends Scalar
         return new LNumber(intval($str, 8), $attributes);
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Scalar_LNumber';
     }
 }

--- a/lib/PhpParser/Node/Scalar/MagicConst/Class_.php
+++ b/lib/PhpParser/Node/Scalar/MagicConst/Class_.php
@@ -10,7 +10,7 @@ class Class_ extends MagicConst
         return '__CLASS__';
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Scalar_MagicConst_Class';
     }
 }

--- a/lib/PhpParser/Node/Scalar/MagicConst/Dir.php
+++ b/lib/PhpParser/Node/Scalar/MagicConst/Dir.php
@@ -10,7 +10,7 @@ class Dir extends MagicConst
         return '__DIR__';
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Scalar_MagicConst_Dir';
     }
 }

--- a/lib/PhpParser/Node/Scalar/MagicConst/File.php
+++ b/lib/PhpParser/Node/Scalar/MagicConst/File.php
@@ -10,7 +10,7 @@ class File extends MagicConst
         return '__FILE__';
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Scalar_MagicConst_File';
     }
 }

--- a/lib/PhpParser/Node/Scalar/MagicConst/Function_.php
+++ b/lib/PhpParser/Node/Scalar/MagicConst/Function_.php
@@ -10,7 +10,7 @@ class Function_ extends MagicConst
         return '__FUNCTION__';
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Scalar_MagicConst_Function';
     }
 }

--- a/lib/PhpParser/Node/Scalar/MagicConst/Line.php
+++ b/lib/PhpParser/Node/Scalar/MagicConst/Line.php
@@ -10,7 +10,7 @@ class Line extends MagicConst
         return '__LINE__';
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Scalar_MagicConst_Line';
     }
 }

--- a/lib/PhpParser/Node/Scalar/MagicConst/Method.php
+++ b/lib/PhpParser/Node/Scalar/MagicConst/Method.php
@@ -10,7 +10,7 @@ class Method extends MagicConst
         return '__METHOD__';
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Scalar_MagicConst_Method';
     }
 }

--- a/lib/PhpParser/Node/Scalar/MagicConst/Namespace_.php
+++ b/lib/PhpParser/Node/Scalar/MagicConst/Namespace_.php
@@ -10,7 +10,7 @@ class Namespace_ extends MagicConst
         return '__NAMESPACE__';
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Scalar_MagicConst_Namespace';
     }
 }

--- a/lib/PhpParser/Node/Scalar/MagicConst/Trait_.php
+++ b/lib/PhpParser/Node/Scalar/MagicConst/Trait_.php
@@ -10,7 +10,7 @@ class Trait_ extends MagicConst
         return '__TRAIT__';
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Scalar_MagicConst_Trait';
     }
 }

--- a/lib/PhpParser/Node/Scalar/String_.php
+++ b/lib/PhpParser/Node/Scalar/String_.php
@@ -158,7 +158,7 @@ class String_ extends Scalar
         return self::parseEscapeSequences($str, null, $parseUnicodeEscape);
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Scalar_String';
     }
 }

--- a/lib/PhpParser/Node/Stmt/Break_.php
+++ b/lib/PhpParser/Node/Stmt/Break_.php
@@ -24,7 +24,7 @@ class Break_ extends Node\Stmt
         return ['num'];
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Stmt_Break';
     }
 }

--- a/lib/PhpParser/Node/Stmt/Case_.php
+++ b/lib/PhpParser/Node/Stmt/Case_.php
@@ -28,7 +28,7 @@ class Case_ extends Node\Stmt
         return ['cond', 'stmts'];
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Stmt_Case';
     }
 }

--- a/lib/PhpParser/Node/Stmt/Catch_.php
+++ b/lib/PhpParser/Node/Stmt/Catch_.php
@@ -35,7 +35,7 @@ class Catch_ extends Node\Stmt
         return ['types', 'var', 'stmts'];
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Stmt_Catch';
     }
 }

--- a/lib/PhpParser/Node/Stmt/ClassConst.php
+++ b/lib/PhpParser/Node/Stmt/ClassConst.php
@@ -56,7 +56,7 @@ class ClassConst extends Node\Stmt
         return (bool) ($this->flags & Class_::MODIFIER_PRIVATE);
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Stmt_ClassConst';
     }
 }

--- a/lib/PhpParser/Node/Stmt/ClassMethod.php
+++ b/lib/PhpParser/Node/Stmt/ClassMethod.php
@@ -145,7 +145,7 @@ class ClassMethod extends Node\Stmt implements FunctionLike
         return isset(self::$magicNames[$this->name->toLowerString()]);
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Stmt_ClassMethod';
     }
 }

--- a/lib/PhpParser/Node/Stmt/Class_.php
+++ b/lib/PhpParser/Node/Stmt/Class_.php
@@ -99,7 +99,7 @@ class Class_ extends ClassLike
         }
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Stmt_Class';
     }
 }

--- a/lib/PhpParser/Node/Stmt/Const_.php
+++ b/lib/PhpParser/Node/Stmt/Const_.php
@@ -24,7 +24,7 @@ class Const_ extends Node\Stmt
         return ['consts'];
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Stmt_Const';
     }
 }

--- a/lib/PhpParser/Node/Stmt/Continue_.php
+++ b/lib/PhpParser/Node/Stmt/Continue_.php
@@ -24,7 +24,7 @@ class Continue_ extends Node\Stmt
         return ['num'];
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Stmt_Continue';
     }
 }

--- a/lib/PhpParser/Node/Stmt/DeclareDeclare.php
+++ b/lib/PhpParser/Node/Stmt/DeclareDeclare.php
@@ -28,7 +28,7 @@ class DeclareDeclare extends Node\Stmt
         return ['key', 'value'];
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Stmt_DeclareDeclare';
     }
 }

--- a/lib/PhpParser/Node/Stmt/Declare_.php
+++ b/lib/PhpParser/Node/Stmt/Declare_.php
@@ -28,7 +28,7 @@ class Declare_ extends Node\Stmt
         return ['declares', 'stmts'];
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Stmt_Declare';
     }
 }

--- a/lib/PhpParser/Node/Stmt/Do_.php
+++ b/lib/PhpParser/Node/Stmt/Do_.php
@@ -28,7 +28,7 @@ class Do_ extends Node\Stmt
         return ['stmts', 'cond'];
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Stmt_Do';
     }
 }

--- a/lib/PhpParser/Node/Stmt/Echo_.php
+++ b/lib/PhpParser/Node/Stmt/Echo_.php
@@ -24,7 +24,7 @@ class Echo_ extends Node\Stmt
         return ['exprs'];
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Stmt_Echo';
     }
 }

--- a/lib/PhpParser/Node/Stmt/ElseIf_.php
+++ b/lib/PhpParser/Node/Stmt/ElseIf_.php
@@ -28,7 +28,7 @@ class ElseIf_ extends Node\Stmt
         return ['cond', 'stmts'];
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Stmt_ElseIf';
     }
 }

--- a/lib/PhpParser/Node/Stmt/Else_.php
+++ b/lib/PhpParser/Node/Stmt/Else_.php
@@ -24,7 +24,7 @@ class Else_ extends Node\Stmt
         return ['stmts'];
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Stmt_Else';
     }
 }

--- a/lib/PhpParser/Node/Stmt/Expression.php
+++ b/lib/PhpParser/Node/Stmt/Expression.php
@@ -27,7 +27,7 @@ class Expression extends Node\Stmt
         return ['expr'];
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Stmt_Expression';
     }
 }

--- a/lib/PhpParser/Node/Stmt/Finally_.php
+++ b/lib/PhpParser/Node/Stmt/Finally_.php
@@ -24,7 +24,7 @@ class Finally_ extends Node\Stmt
         return ['stmts'];
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Stmt_Finally';
     }
 }

--- a/lib/PhpParser/Node/Stmt/For_.php
+++ b/lib/PhpParser/Node/Stmt/For_.php
@@ -37,7 +37,7 @@ class For_ extends Node\Stmt
         return ['init', 'cond', 'loop', 'stmts'];
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Stmt_For';
     }
 }

--- a/lib/PhpParser/Node/Stmt/Foreach_.php
+++ b/lib/PhpParser/Node/Stmt/Foreach_.php
@@ -41,7 +41,7 @@ class Foreach_ extends Node\Stmt
         return ['expr', 'keyVar', 'byRef', 'valueVar', 'stmts'];
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Stmt_Foreach';
     }
 }

--- a/lib/PhpParser/Node/Stmt/Function_.php
+++ b/lib/PhpParser/Node/Stmt/Function_.php
@@ -63,7 +63,7 @@ class Function_ extends Node\Stmt implements FunctionLike
         return $this->stmts;
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Stmt_Function';
     }
 }

--- a/lib/PhpParser/Node/Stmt/Global_.php
+++ b/lib/PhpParser/Node/Stmt/Global_.php
@@ -24,7 +24,7 @@ class Global_ extends Node\Stmt
         return ['vars'];
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Stmt_Global';
     }
 }

--- a/lib/PhpParser/Node/Stmt/Goto_.php
+++ b/lib/PhpParser/Node/Stmt/Goto_.php
@@ -25,7 +25,7 @@ class Goto_ extends Stmt
         return ['name'];
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Stmt_Goto';
     }
 }

--- a/lib/PhpParser/Node/Stmt/GroupUse.php
+++ b/lib/PhpParser/Node/Stmt/GroupUse.php
@@ -33,7 +33,7 @@ class GroupUse extends Stmt
         return ['type', 'prefix', 'uses'];
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Stmt_GroupUse';
     }
 }

--- a/lib/PhpParser/Node/Stmt/HaltCompiler.php
+++ b/lib/PhpParser/Node/Stmt/HaltCompiler.php
@@ -24,7 +24,7 @@ class HaltCompiler extends Stmt
         return ['remaining'];
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Stmt_HaltCompiler';
     }
 }

--- a/lib/PhpParser/Node/Stmt/If_.php
+++ b/lib/PhpParser/Node/Stmt/If_.php
@@ -37,7 +37,7 @@ class If_ extends Node\Stmt
         return ['cond', 'stmts', 'elseifs', 'else'];
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Stmt_If';
     }
 }

--- a/lib/PhpParser/Node/Stmt/InlineHTML.php
+++ b/lib/PhpParser/Node/Stmt/InlineHTML.php
@@ -24,7 +24,7 @@ class InlineHTML extends Stmt
         return ['value'];
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Stmt_InlineHTML';
     }
 }

--- a/lib/PhpParser/Node/Stmt/Interface_.php
+++ b/lib/PhpParser/Node/Stmt/Interface_.php
@@ -29,7 +29,7 @@ class Interface_ extends ClassLike
         return ['name', 'extends', 'stmts'];
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Stmt_Interface';
     }
 }

--- a/lib/PhpParser/Node/Stmt/Label.php
+++ b/lib/PhpParser/Node/Stmt/Label.php
@@ -25,7 +25,7 @@ class Label extends Stmt
         return ['name'];
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Stmt_Label';
     }
 }

--- a/lib/PhpParser/Node/Stmt/Namespace_.php
+++ b/lib/PhpParser/Node/Stmt/Namespace_.php
@@ -32,7 +32,7 @@ class Namespace_ extends Node\Stmt
         return ['name', 'stmts'];
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Stmt_Namespace';
     }
 }

--- a/lib/PhpParser/Node/Stmt/Nop.php
+++ b/lib/PhpParser/Node/Stmt/Nop.php
@@ -11,7 +11,7 @@ class Nop extends Node\Stmt
         return [];
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Stmt_Nop';
     }
 }

--- a/lib/PhpParser/Node/Stmt/Property.php
+++ b/lib/PhpParser/Node/Stmt/Property.php
@@ -65,7 +65,7 @@ class Property extends Node\Stmt
         return (bool) ($this->flags & Class_::MODIFIER_STATIC);
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Stmt_Property';
     }
 }

--- a/lib/PhpParser/Node/Stmt/PropertyProperty.php
+++ b/lib/PhpParser/Node/Stmt/PropertyProperty.php
@@ -28,7 +28,7 @@ class PropertyProperty extends Node\Stmt
         return ['name', 'default'];
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Stmt_PropertyProperty';
     }
 }

--- a/lib/PhpParser/Node/Stmt/Return_.php
+++ b/lib/PhpParser/Node/Stmt/Return_.php
@@ -24,7 +24,7 @@ class Return_ extends Node\Stmt
         return ['expr'];
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Stmt_Return';
     }
 }

--- a/lib/PhpParser/Node/Stmt/StaticVar.php
+++ b/lib/PhpParser/Node/Stmt/StaticVar.php
@@ -31,7 +31,7 @@ class StaticVar extends Node\Stmt
         return ['var', 'default'];
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Stmt_StaticVar';
     }
 }

--- a/lib/PhpParser/Node/Stmt/Static_.php
+++ b/lib/PhpParser/Node/Stmt/Static_.php
@@ -24,7 +24,7 @@ class Static_ extends Stmt
         return ['vars'];
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Stmt_Static';
     }
 }

--- a/lib/PhpParser/Node/Stmt/Switch_.php
+++ b/lib/PhpParser/Node/Stmt/Switch_.php
@@ -28,7 +28,7 @@ class Switch_ extends Node\Stmt
         return ['cond', 'cases'];
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Stmt_Switch';
     }
 }

--- a/lib/PhpParser/Node/Stmt/Throw_.php
+++ b/lib/PhpParser/Node/Stmt/Throw_.php
@@ -24,7 +24,7 @@ class Throw_ extends Node\Stmt
         return ['expr'];
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Stmt_Throw';
     }
 }

--- a/lib/PhpParser/Node/Stmt/TraitUse.php
+++ b/lib/PhpParser/Node/Stmt/TraitUse.php
@@ -29,7 +29,7 @@ class TraitUse extends Node\Stmt
         return ['traits', 'adaptations'];
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Stmt_TraitUse';
     }
 }

--- a/lib/PhpParser/Node/Stmt/TraitUseAdaptation/Alias.php
+++ b/lib/PhpParser/Node/Stmt/TraitUseAdaptation/Alias.php
@@ -32,7 +32,7 @@ class Alias extends Node\Stmt\TraitUseAdaptation
         return ['trait', 'method', 'newModifier', 'newName'];
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Stmt_TraitUseAdaptation_Alias';
     }
 }

--- a/lib/PhpParser/Node/Stmt/TraitUseAdaptation/Precedence.php
+++ b/lib/PhpParser/Node/Stmt/TraitUseAdaptation/Precedence.php
@@ -28,7 +28,7 @@ class Precedence extends Node\Stmt\TraitUseAdaptation
         return ['trait', 'method', 'insteadof'];
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Stmt_TraitUseAdaptation_Precedence';
     }
 }

--- a/lib/PhpParser/Node/Stmt/Trait_.php
+++ b/lib/PhpParser/Node/Stmt/Trait_.php
@@ -24,7 +24,7 @@ class Trait_ extends ClassLike
         return ['name', 'stmts'];
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Stmt_Trait';
     }
 }

--- a/lib/PhpParser/Node/Stmt/TryCatch.php
+++ b/lib/PhpParser/Node/Stmt/TryCatch.php
@@ -32,7 +32,7 @@ class TryCatch extends Node\Stmt
         return ['stmts', 'catches', 'finally'];
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Stmt_TryCatch';
     }
 }

--- a/lib/PhpParser/Node/Stmt/Unset_.php
+++ b/lib/PhpParser/Node/Stmt/Unset_.php
@@ -24,7 +24,7 @@ class Unset_ extends Node\Stmt
         return ['vars'];
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Stmt_Unset';
     }
 }

--- a/lib/PhpParser/Node/Stmt/UseUse.php
+++ b/lib/PhpParser/Node/Stmt/UseUse.php
@@ -46,7 +46,7 @@ class UseUse extends Node\Stmt
         return new Identifier($this->name->getLast());
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Stmt_UseUse';
     }
 }

--- a/lib/PhpParser/Node/Stmt/Use_.php
+++ b/lib/PhpParser/Node/Stmt/Use_.php
@@ -41,7 +41,7 @@ class Use_ extends Stmt
         return ['type', 'uses'];
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Stmt_Use';
     }
 }

--- a/lib/PhpParser/Node/Stmt/While_.php
+++ b/lib/PhpParser/Node/Stmt/While_.php
@@ -28,7 +28,7 @@ class While_ extends Node\Stmt
         return ['cond', 'stmts'];
     }
     
-    function getType() : string {
+    public function getType() : string {
         return 'Stmt_While';
     }
 }

--- a/lib/PhpParser/Node/VarLikeIdentifier.php
+++ b/lib/PhpParser/Node/VarLikeIdentifier.php
@@ -11,7 +11,7 @@ namespace PhpParser\Node;
  */
 class VarLikeIdentifier extends Identifier
 {
-    function getType() : string {
+    public function getType() : string {
         return 'VarLikeIdentifier';
     }
 }


### PR DESCRIPTION
[Following](https://github.com/nikic/PHP-Parser/commit/1c11626f0a2fda566d9db9f388feb0682093955a#commitcomment-26768631)

@nikic There are some others methods that are missing visibility in the core, but I'll PR separate