### PR TITLE
Replace string by class call

### DIFF
--- a/lib/PhpParser/NodeAbstract.php
+++ b/lib/PhpParser/NodeAbstract.php
@@ -25,10 +25,7 @@ abstract class NodeAbstract implements Node, \JsonSerializable
     public function getType() {
         $className = rtrim(get_class($this), '_');
         return strtr(
-            substr(
-                $className,
-                strpos($className, Node::class) + strlen(Node::class) + 1
-            ),
+            substr($className, strlen(Node::class) + 1),
             '\\',
             '_'
         );

--- a/lib/PhpParser/NodeAbstract.php
+++ b/lib/PhpParser/NodeAbstract.php
@@ -2,6 +2,8 @@
 
 namespace PhpParser;
 
+use PhpParser\Node;
+
 abstract class NodeAbstract implements Node, \JsonSerializable
 {
     protected $attributes;
@@ -25,7 +27,7 @@ abstract class NodeAbstract implements Node, \JsonSerializable
         return strtr(
             substr(
                 $className,
-                strpos($className, 'PhpParser\Node') + 15
+                strpos($className, Node::class) + strlen(Node::class) + 1
             ),
             '\\',
             '_'


### PR DESCRIPTION
This ensures this piece of code is still working after changing the namespace of the class like done with [PHP-Scoper](https://github.com/humbug/php-scoper)