### PR TITLE
Fix Name\Relative result

### DIFF
--- a/lib/PhpParser/Node/Name/Relative.php
+++ b/lib/PhpParser/Node/Name/Relative.php
@@ -41,7 +41,7 @@ class Relative extends \PhpParser\Node\Name
     }
 
     public function toCodeString() : string {
-        return 'namespace\\' . $this->toString();
+        return $this->toString();
     }
     
     public function getType() : string {

--- a/test/PhpParser/Node/NameTest.php
+++ b/test/PhpParser/Node/NameTest.php
@@ -128,7 +128,7 @@ class NameTest extends TestCase
         $this->assertFalse($name->isQualified());
         $this->assertFalse($name->isFullyQualified());
         $this->assertTrue($name->isRelative());
-        $this->assertSame('namespace\foo', $name->toCodeString());
+        $this->assertSame('foo', $name->toCodeString());
     }
 
     /**


### PR DESCRIPTION
Sorry if it is a misunderstood trivial change, but shouldn't `Relative` print 

```diff
-namespace\Foo::class
+Foo::class
```

If not, what should I use to create relatives `::class`? :)

Ref: https://github.com/rectorphp/rector/pull/379