### PR TITLE
Update 2_Usage_of_basic_components.markdown

### DIFF
--- a/doc/2_Usage_of_basic_components.markdown
+++ b/doc/2_Usage_of_basic_components.markdown
@@ -409,7 +409,7 @@ $files = new \RegexIterator($files, '/\.php$/');
 foreach ($files as $file) {
     try {
         // read the file that should be converted
-        $code = file_get_contents($file);
+        $code = file_get_contents($file->getPathName());
 
         // parse
         $stmts = $parser->parse($code);


### PR DESCRIPTION
1 function call was missing from the docs, which made the tutorial crash.