### PR TITLE
Fix short array syntax

### DIFF
--- a/lib/PhpParser/PrettyPrinter/Standard.php
+++ b/lib/PhpParser/PrettyPrinter/Standard.php
@@ -518,8 +518,14 @@ class Standard extends PrettyPrinterAbstract
     }
 
     protected function pExpr_Array(Expr\Array_ $node) {
-        $syntax = $node->getAttribute('kind',
-            $this->options['shortArraySyntax'] ? Expr\Array_::KIND_SHORT : Expr\Array_::KIND_LONG);
+        if (!$this->options['shortArraySyntax']) {
+            $syntax = Expr\Array_::KIND_LONG;
+        } else {
+            $syntax = $node->getAttribute(
+                'kind',
+                $this->options['shortArraySyntax'] ? Expr\Array_::KIND_SHORT : Expr\Array_::KIND_LONG
+            );
+        }
         if ($syntax === Expr\Array_::KIND_SHORT) {
             return '[' . $this->pMaybeMultiline($node->items, true) . ']';
         } else {


### PR DESCRIPTION
Ensures that when the long array syntax is enforced, e.g. for PHP 5.3 compatible code, it is properly picked.

The change can be ported to master as well.