### PR TITLE
Remove flags from phpunit.xml that have default value and colorize

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,14 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <phpunit backupGlobals="false"
-         backupStaticAttributes="false"
-         colors="false"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false"
-         syntaxCheck="false"
+         colors="true"
          beStrictAboutTestsThatDoNotTestAnything="false"
          bootstrap="./test/bootstrap.php">
     <testsuites>


### PR DESCRIPTION
A little improvement for `phpunit.xml.dist`: remove flags that have the default value [as upstream](https://phpunit.de/manual/6.5/en/appendixes.configuration.html) and colorize the output with `colors=true` :)