### PR TITLE
Add security check with $append,it will be an empty string when some special case

### DIFF
--- a/lib/PhpParser/PrettyPrinterAbstract.php
+++ b/lib/PhpParser/PrettyPrinterAbstract.php
@@ -957,6 +957,10 @@ abstract class PrettyPrinterAbstract
             return;
         }
 
+        if ($append === "") {
+            return;
+        }
+
         if (!$this->labelCharMap[$append[0]]
                 || !$this->labelCharMap[$str[\strlen($str) - 1]]) {
             $str .= $append;


### PR DESCRIPTION
I add a security check for variable ‘$append’ ,Because it will be an empty string in my project use PHP-parser.
This will produce one Notice like **"PHP Notice:  Uninitialized string offset: 0".** 

In my project, I want to add some comment information at the end of the PHP file. I created an Stmt\Nop and set the comment information.then append it into stmts[].Just at the same time，
I deleted some nodes so that the length of stmts[] is exactly the same as the original.

Case like follow：
```
class DeleteVisitor extends NodeVisitorAbstract
{
    public function leaveNode(Node $node) {
        if ('Stmt_Use' == $node->getType()) {
            return \PhpParser\NodeTraverser::REMOVE_NODE;
        }

        return parent::leaveNode($node);
    }
}

$code = <<<'CODE'
<?php
use a\b;
class MyClass
{
    public function f1() {
        echo "jack";
    }
}
CODE;

$lexer = new Lexer\Emulative([
    'usedAttributes' => [
        'comments',
        'startLine', 'endLine',
        'startTokenPos', 'endTokenPos',
    ],
]);
$parser    = new Parser\Php7($lexer);
$oldStmts  = $parser->parse($code);
$oldTokens = $lexer->getTokens();

$traver = new NodeTraverser();
$traver->addVisitor(new DeleteVisitor());

$stmts = $traver->traverse($oldStmts);

$newNode = new Nop();
$newNode->setDocComment(new Doc('//Some comment here'));
$stmts[] = $newNode;


echo (new PrettyPrinter\Standard())->printFormatPreserving($stmts, $oldStmts, $oldTokens);
```