### PR TITLE
TraitUse and TraitUseAdaptation builders

### DIFF
--- a/lib/PhpParser/Builder/TraitUse.php
+++ b/lib/PhpParser/Builder/TraitUse.php
@@ -1,0 +1,60 @@
+<?php declare(strict_types=1);
+
+namespace PhpParser\Builder;
+
+use PhpParser\Builder;
+use PhpParser\BuilderHelpers;
+use PhpParser\Node;
+use PhpParser\Node\Stmt;
+use PhpParser\Node\Stmt\TraitUseAdaptation;
+
+class TraitUse implements Builder
+{
+    protected $traits = [];
+    protected $adaptations = [];
+
+    /**
+     * Creates a trait use builder.
+     *
+     * @param Node\Name|string ...$traits Names of used traits
+     */
+    public function __construct(...$traits) {
+        $this->and(...$traits);
+    }
+
+    /**
+     * Adds used traits.
+     *
+     * @param Node\Name|string ...$traits Trait names
+     *
+     * @return $this The builder instance (for fluid interface)
+     */
+    public function and(...$traits) {
+        foreach ($traits as $trait) {
+            $this->traits[] = BuilderHelpers::normalizeName($trait);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Adds trait adaptation.
+     *
+     * @param TraitUseAdaptation $adaptation Trait adaptation
+     *
+     * @return $this The builder instance (for fluid interface)
+     */
+    public function with(TraitUseAdaptation $adaptation) {
+        $this->adaptations[] = $adaptation;
+        return $this;
+    }
+
+    /**
+     * Returns the built node.
+     *
+     * @return Node The built node
+     */
+    public function getNode() : Node {
+        return new Stmt\TraitUse($this->traits, $this->adaptations);
+    }
+}

--- a/lib/PhpParser/Builder/TraitUse.php
+++ b/lib/PhpParser/Builder/TraitUse.php
@@ -18,21 +18,20 @@ class TraitUse implements Builder
      * @param Node\Name|string ...$traits Names of used traits
      */
     public function __construct(...$traits) {
-        $this->and(...$traits);
+        foreach ($traits as $trait) {
+            $this->and($trait);
+        }
     }
 
     /**
-     * Adds used traits.
+     * Adds used trait.
      *
-     * @param Node\Name|string ...$traits Trait names
+     * @param Node\Name|string $trait Trait name
      *
      * @return $this The builder instance (for fluid interface)
      */
-    public function and(...$traits) {
-        foreach ($traits as $trait) {
-            $this->traits[] = BuilderHelpers::normalizeName($trait);
-        }
-
+    public function and($trait) {
+        $this->traits[] = BuilderHelpers::normalizeName($trait);
         return $this;
     }
 

--- a/lib/PhpParser/Builder/TraitUse.php
+++ b/lib/PhpParser/Builder/TraitUse.php
@@ -6,7 +6,6 @@ use PhpParser\Builder;
 use PhpParser\BuilderHelpers;
 use PhpParser\Node;
 use PhpParser\Node\Stmt;
-use PhpParser\Node\Stmt\TraitUseAdaptation;
 
 class TraitUse implements Builder
 {
@@ -40,11 +39,17 @@ class TraitUse implements Builder
     /**
      * Adds trait adaptation.
      *
-     * @param TraitUseAdaptation $adaptation Trait adaptation
+     * @param Stmt\TraitUseAdaptation|Builder\TraitUseAdaptation $adaptation Trait adaptation
      *
      * @return $this The builder instance (for fluid interface)
      */
-    public function with(TraitUseAdaptation $adaptation) {
+    public function with($adaptation) {
+        $adaptation = BuilderHelpers::normalizeNode($adaptation);
+
+        if (!$adaptation instanceof Stmt\TraitUseAdaptation) {
+            throw new \LogicException('Adaptation must have type TraitUseAdaptation');
+        }
+
         $this->adaptations[] = $adaptation;
         return $this;
     }

--- a/lib/PhpParser/Builder/TraitUseAdaptation.php
+++ b/lib/PhpParser/Builder/TraitUseAdaptation.php
@@ -1,0 +1,148 @@
+<?php declare(strict_types=1);
+
+namespace PhpParser\Builder;
+
+use PhpParser\Builder;
+use PhpParser\BuilderHelpers;
+use PhpParser\Node;
+use PhpParser\Node\Stmt;
+
+class TraitUseAdaptation implements Builder
+{
+    protected const TYPE_UNDEFINED  = 0;
+    protected const TYPE_ALIAS      = 1;
+    protected const TYPE_PRECEDENCE = 2;
+
+    /** @var int Type of building adaptation */
+    protected $type;
+
+    protected $trait;
+    protected $method;
+
+    protected $modifier = null;
+    protected $alias = null;
+
+    protected $insteadof = [];
+
+    /**
+     * Creates a trait use adaptation builder.
+     *
+     * @param Node\Name|string|null  $trait  Name of adaptated trait
+     * @param Node\Identifier|string $method Name of adaptated method
+     */
+    public function __construct($trait, $method) {
+        $this->type = self::TYPE_UNDEFINED;
+
+        $this->trait = is_null($trait)? null: BuilderHelpers::normalizeName($trait);
+        $this->method = BuilderHelpers::normalizeIdentifier($method);
+    }
+
+    /**
+     * Sets alias of method.
+     *
+     * @param Node\Identifier|string $alias Alias for adaptated method
+     *
+     * @return $this The builder instance (for fluid interface)
+     */
+    public function as($alias) {
+        if ($this->type === self::TYPE_UNDEFINED) {
+            $this->type = self::TYPE_ALIAS;
+        }
+
+        if ($this->type !== self::TYPE_ALIAS) {
+            throw new \LogicException('Cannot set alias for not alias adaptation buider');
+        }
+
+        $this->alias = $alias;
+        return $this;
+    }
+
+    /**
+     * Sets adaptated method public.
+     *
+     * @return $this The builder instance (for fluid interface)
+     */
+    public function makePublic() {
+        $this->setModifier(Stmt\Class_::MODIFIER_PUBLIC);
+        return $this;
+    }
+
+    /**
+     * Sets adaptated method protected.
+     *
+     * @return $this The builder instance (for fluid interface)
+     */
+    public function makeProtected() {
+        $this->setModifier(Stmt\Class_::MODIFIER_PROTECTED);
+        return $this;
+    }
+
+    /**
+     * Sets adaptated method private.
+     *
+     * @return $this The builder instance (for fluid interface)
+     */
+    public function makePrivate() {
+        $this->setModifier(Stmt\Class_::MODIFIER_PRIVATE);
+        return $this;
+    }
+
+    /**
+     * Adds overwritten traits.
+     *
+     * @param Node\Name|string ...$traits Traits for overwrite
+     *
+     * @return $this The builder instance (for fluid interface)
+     */
+    public function insteadof(...$traits) {
+        if ($this->type === self::TYPE_UNDEFINED) {
+            $this->type = self::TYPE_PRECEDENCE;
+        }
+
+        if ($this->type !== self::TYPE_PRECEDENCE) {
+            throw new \LogicException('Cannot add overwritten traits for not precedence adaptation buider');
+        }
+
+        foreach ($traits as $trait) {
+            $this->insteadof[] = BuilderHelpers::normalizeName($trait);
+        }
+
+        return $this;
+    }
+
+    protected function setModifier(int $modifier) {
+        if ($this->type === self::TYPE_UNDEFINED) {
+            $this->type = self::TYPE_ALIAS;
+        }
+
+        if ($this->type !== self::TYPE_ALIAS) {
+            throw new \LogicException('Cannot set alias for not alias adaptation buider');
+        }
+
+        if (is_null($this->modifier)) {
+            $this->modifier = $modifier;
+        } else {
+            throw new \LogicException('Multiple access type modifiers are not allowed');
+        }
+    }
+
+    /**
+     * Returns the built node.
+     *
+     * @return Node The built node
+     */
+    public function getNode() : Node {
+        switch ($this->type) {
+            case self::TYPE_ALIAS:
+                return new Stmt\TraitUseAdaptation\Alias($this->trait, $this->method, $this->modifier, $this->alias);
+            case self::TYPE_PRECEDENCE:
+                if (is_null($this->trait)) {
+                    throw new \LogicException('Cannot build precedence adaptation without trait');
+                }
+
+                return new Stmt\TraitUseAdaptation\Precedence($this->trait, $this->method, $this->insteadof);
+            default:
+                throw new \LogicException('Type of adaptation is not defined');
+        }
+    }
+}

--- a/lib/PhpParser/Builder/TraitUseAdaptation.php
+++ b/lib/PhpParser/Builder/TraitUseAdaptation.php
@@ -96,6 +96,10 @@ class TraitUseAdaptation implements Builder
      */
     public function insteadof(...$traits) {
         if ($this->type === self::TYPE_UNDEFINED) {
+            if (is_null($this->trait)) {
+                throw new \LogicException('Precedence adaptation must have trait');
+            }
+
             $this->type = self::TYPE_PRECEDENCE;
         }
 
@@ -116,7 +120,7 @@ class TraitUseAdaptation implements Builder
         }
 
         if ($this->type !== self::TYPE_ALIAS) {
-            throw new \LogicException('Cannot set alias for not alias adaptation buider');
+            throw new \LogicException('Cannot set access modifier for not alias adaptation buider');
         }
 
         if (is_null($this->modifier)) {
@@ -136,10 +140,6 @@ class TraitUseAdaptation implements Builder
             case self::TYPE_ALIAS:
                 return new Stmt\TraitUseAdaptation\Alias($this->trait, $this->method, $this->modifier, $this->alias);
             case self::TYPE_PRECEDENCE:
-                if (is_null($this->trait)) {
-                    throw new \LogicException('Cannot build precedence adaptation without trait');
-                }
-
                 return new Stmt\TraitUseAdaptation\Precedence($this->trait, $this->method, $this->insteadof);
             default:
                 throw new \LogicException('Type of adaptation is not defined');

--- a/lib/PhpParser/Builder/TraitUseAdaptation.php
+++ b/lib/PhpParser/Builder/TraitUseAdaptation.php
@@ -9,9 +9,9 @@ use PhpParser\Node\Stmt;
 
 class TraitUseAdaptation implements Builder
 {
-    protected const TYPE_UNDEFINED  = 0;
-    protected const TYPE_ALIAS      = 1;
-    protected const TYPE_PRECEDENCE = 2;
+    const TYPE_UNDEFINED  = 0;
+    const TYPE_ALIAS      = 1;
+    const TYPE_PRECEDENCE = 2;
 
     /** @var int Type of building adaptation */
     protected $type;

--- a/lib/PhpParser/BuilderFactory.php
+++ b/lib/PhpParser/BuilderFactory.php
@@ -69,6 +69,23 @@ class BuilderFactory
     }
 
     /**
+     * Creates a trait use adaptation builder.
+     *
+     * @param Node\Name|string|null  $trait  Trait name
+     * @param Node\Identifier|string $method Method name
+     *
+     * @return Builder\TraitUseAdaptation The create trait use adaptation builder
+     */
+    public function traitUseAdaptation($trait, $method = null) : Builder\TraitUseAdaptation {
+        if (is_null($method)) {
+            $method = $trait;
+            $trait = null;
+        }
+
+        return new Builder\TraitUseAdaptation($trait, $method);
+    }
+
+    /**
      * Creates a method builder.
      *
      * @param string $name Name of the method

--- a/lib/PhpParser/BuilderFactory.php
+++ b/lib/PhpParser/BuilderFactory.php
@@ -58,6 +58,17 @@ class BuilderFactory
     }
 
     /**
+     * Creates a trait use builder.
+     *
+     * @param Node\Name|string ...$traits Trait names
+     *
+     * @return Builder\TraitUse The create trait use builder
+     */
+    public function useTrait(...$traits) : Builder\TraitUse {
+        return new Builder\TraitUse(...$traits);
+    }
+
+    /**
      * Creates a method builder.
      *
      * @param string $name Name of the method

--- a/test/PhpParser/Builder/TraitUseAdaptationTest.php
+++ b/test/PhpParser/Builder/TraitUseAdaptationTest.php
@@ -1,0 +1,121 @@
+<?php declare(strict_types=1);
+
+namespace PhpParser\Builder;
+
+use PhpParser\Comment;
+use PhpParser\Node;
+use PhpParser\Node\Name;
+use PhpParser\Node\Stmt;
+use PhpParser\Node\Stmt\Class_;
+use PHPUnit\Framework\TestCase;
+
+class TraitUseAdaptationTest extends TestCase
+{
+    protected function createTraitUseAdaptationBuilder($trait, $method) {
+        return new TraitUseAdaptation($trait, $method);
+    }
+
+    public function testAsMake() {
+        $builder = $this->createTraitUseAdaptationBuilder(null, 'foo');
+
+        $this->assertEquals(
+            new Stmt\TraitUseAdaptation\Alias(null, 'foo', null, 'bar'),
+            (clone $builder)->as('bar')->getNode()
+        );
+
+        $this->assertEquals(
+            new Stmt\TraitUseAdaptation\Alias(null, 'foo', Class_::MODIFIER_PUBLIC, null),
+            (clone $builder)->makePublic()->getNode()
+        );
+
+        $this->assertEquals(
+            new Stmt\TraitUseAdaptation\Alias(null, 'foo', Class_::MODIFIER_PROTECTED, null),
+            (clone $builder)->makeProtected()->getNode()
+        );
+
+        $this->assertEquals(
+            new Stmt\TraitUseAdaptation\Alias(null, 'foo', Class_::MODIFIER_PRIVATE, null),
+            (clone $builder)->makePrivate()->getNode()
+        );
+    }
+
+    public function testInsteadof() {
+        $node = $this->createTraitUseAdaptationBuilder('SomeTrait', 'foo')
+            ->insteadof('AnotherTrait')
+            ->getNode()
+        ;
+
+        $this->assertEquals(
+            new Stmt\TraitUseAdaptation\Precedence(
+                new Name('SomeTrait'),
+                'foo',
+                [new Name('AnotherTrait')]
+            ),
+            $node
+        );
+    }
+
+    /**
+     * @expectedException \LogicException
+     * @expectedExceptionMessage Cannot set alias for not alias adaptation buider
+     */
+    public function testAsOnNotAlias() {
+        $this->createTraitUseAdaptationBuilder('Test', 'foo')
+            ->insteadof('AnotherTrait')
+            ->as('bar')
+        ;
+    }
+
+    /**
+     * @expectedException \LogicException
+     * @expectedExceptionMessage Cannot add overwritten traits for not precedence adaptation buider
+     */
+    public function testInsteadofOnNotPrecedence() {
+        $this->createTraitUseAdaptationBuilder('Test', 'foo')
+            ->as('bar')
+            ->insteadof('AnotherTrait')
+        ;
+    }
+
+    /**
+     * @expectedException \LogicException
+     * @expectedExceptionMessage Precedence adaptation must have trait
+     */
+    public function testInsteadofWithoutTrait() {
+        $this->createTraitUseAdaptationBuilder(null, 'foo')
+            ->insteadof('AnotherTrait')
+        ;
+    }
+
+    /**
+     * @expectedException \LogicException
+     * @expectedExceptionMessage Cannot set access modifier for not alias adaptation buider
+     */
+    public function testMakeOnNotAlias() {
+        $this->createTraitUseAdaptationBuilder('Test', 'foo')
+            ->insteadof('AnotherTrait')
+            ->makePublic()
+        ;
+    }
+
+    /**
+     * @expectedException \LogicException
+     * @expectedExceptionMessage Multiple access type modifiers are not allowed
+     */
+    public function testMultipleMake() {
+        $this->createTraitUseAdaptationBuilder(null, 'foo')
+            ->makePrivate()
+            ->makePublic()
+        ;
+    }
+
+    /**
+     * @expectedException \LogicException
+     * @expectedExceptionMessage Type of adaptation is not defined
+     */
+    public function testUndefinedType() {
+        $this->createTraitUseAdaptationBuilder(null, 'foo')
+            ->getNode()
+        ;
+    }
+}

--- a/test/PhpParser/Builder/TraitUseTest.php
+++ b/test/PhpParser/Builder/TraitUseTest.php
@@ -1,0 +1,57 @@
+<?php declare(strict_types=1);
+
+namespace PhpParser\Builder;
+
+use PhpParser\Comment;
+use PhpParser\Node;
+use PhpParser\Node\Name;
+use PhpParser\Node\Stmt;
+use PHPUnit\Framework\TestCase;
+
+class TraitUseTest extends TestCase
+{
+    protected function createTraitUseBuilder(...$traits) {
+        return new TraitUse(...$traits);
+    }
+
+    public function testAnd() {
+        $node = $this->createTraitUseBuilder('SomeTrait')
+            ->and('AnotherTrait')
+            ->getNode()
+        ;
+
+        $this->assertEquals(
+            new Stmt\TraitUse([
+                new Name('SomeTrait'),
+                new Name('AnotherTrait')
+            ]),
+            $node
+        );
+    }
+
+    public function testWith() {
+        $node = $this->createTraitUseBuilder('SomeTrait')
+            ->with(new Stmt\TraitUseAdaptation\Alias(null, 'foo', null, 'bar'))
+            ->with((new TraitUseAdaptation(null, 'test'))->as('baz'))
+            ->getNode()
+        ;
+
+        $this->assertEquals(
+            new Stmt\TraitUse([new Name('SomeTrait')], [
+                new Stmt\TraitUseAdaptation\Alias(null, 'foo', null, 'bar'),
+                new Stmt\TraitUseAdaptation\Alias(null, 'test', null, 'baz')
+            ]),
+            $node
+        );
+    }
+
+    /**
+     * @expectedException \LogicException
+     * @expectedExceptionMessage Adaptation must have type TraitUseAdaptation
+     */
+    public function testInvalidAdaptationNode() {
+        $this->createTraitUseBuilder('Test')
+            ->with(new Stmt\Echo_([]))
+        ;
+    }
+}

--- a/test/PhpParser/BuilderFactoryTest.php
+++ b/test/PhpParser/BuilderFactoryTest.php
@@ -223,6 +223,14 @@ class BuilderFactoryTest extends TestCase
                 ->implement('A\Few', '\Interfaces')
                 ->makeAbstract()
 
+                ->addStmt($factory->useTrait('FirstTrait'))
+
+                ->addStmt($factory->useTrait('SecondTrait', 'ThirdTrait')
+                    ->and('AnotherTrait')
+                    ->with($factory->traitUseAdaptation('foo')->as('bar'))
+                    ->with($factory->traitUseAdaptation('AnotherTrait', 'baz')->as('test'))
+                    ->with($factory->traitUseAdaptation('AnotherTrait', 'func')->insteadof('SecondTrait')))
+
                 ->addStmt($factory->method('firstMethod'))
 
                 ->addStmt($factory->method('someMethod')
@@ -256,6 +264,12 @@ use Foo\Bar\SomeOtherClass;
 use Foo\Bar as A;
 abstract class SomeClass extends SomeOtherClass implements A\Few, \Interfaces
 {
+    use FirstTrait;
+    use SecondTrait, ThirdTrait, AnotherTrait {
+        foo as bar;
+        AnotherTrait::baz as test;
+        AnotherTrait::func insteadof SecondTrait;
+    }
     protected $someProperty;
     private $anotherProperty = array(1, 2, 3);
     function firstMethod()


### PR DESCRIPTION
I hope I did not violate your code style too much.

#### Note for `BuilderFactory::traitUseAdaptation`:
I have added the ability to specify only the name of the method (skipping `null` for trait name) for more ergonomic:
```php
// $factory->traitUseAdaptation('Bar')->as('Baz')->getNode();
use Foo {
    Bar as Baz;
}

// $factory->traitUseAdaptation('Foo', 'Bar')->as('Baz')->getNode();
use Foo {
    Foo::Bar as Baz;
}
```