### PR TITLE
Failing test case for PrettyPrinter::printFormatPreserving() - lost off line breaks

### DIFF
--- a/test/code/formatPreservation/addInterface.test
+++ b/test/code/formatPreservation/addInterface.test
@@ -1,0 +1,27 @@
+Add interface
+-----
+<?php
+interface Foo {}
+
+class Bar {
+    private $fooProp;
+
+    public function getFooProp()
+    {
+        return $this->fooProp;
+    }
+}
+-----
+$stmts[1]->implements[] = new Node\Name('Foo');
+-----
+<?php
+interface Foo {}
+
+class Bar implements Foo {
+    private $fooProp;
+
+    public function getFooProp()
+    {
+        return $this->fooProp;
+    }
+}


### PR DESCRIPTION
Hi there!

I've *finally* found one small situation where the `printFormatPreserving()` is not *quite* preserving all of the original code/whitespace :). This PR is just the failing test case, as I'm honestly not sure where to look to fix it. Here is the output from the failing test:

```diff
--- Expected
+++ Actual
@@ @@
 '<?php
 interface Foo {}
 
-class Bar implements Foo {
+class Bar implements Foo
+{
     private $fooProp;
-
     public function getFooProp()
     {
         return $this->fooProp;
     }
 }'
```

The movement of the `{` from the class line to the next line is not a huge deal - after all, we *are* modifying this line. The bigger problem is the lost line break between the `$fooProp` property and `getFooProp()`. Actually, *all* line breaks are lost inside the class body. It looks like the modified interface causes `printFormatPreserving()` to think that it needs to re-pretty-print all of the class body.

Do you have any hints on where to look to fix this? Easy fix? Or is this more involved?

Thanks!