### PR TITLE
Remove NodeTraverser dependency on parent::__construct()

### DIFF
--- a/lib/PhpParser/NodeTraverser.php
+++ b/lib/PhpParser/NodeTraverser.php
@@ -31,16 +31,13 @@ class NodeTraverser implements NodeTraverserInterface
     const REMOVE_NODE = 3;
 
     /** @var NodeVisitor[] Visitors */
-    protected $visitors;
+    protected $visitors = [];
 
     /** @var bool Whether traversal should be stopped */
     protected $stopTraversal;
 
-    /**
-     * Constructs a node traverser.
-     */
     public function __construct() {
-        $this->visitors = [];
+        // for BC
     }
 
     /**


### PR DESCRIPTION
At the moment, when `NodeTraverser` is extended and constructor used for dependency injection, there is hidden and unneded dependency on `parent__construct()` call:

```php
use PhpParser\NodeTraverser;

final class NodeTypeResolverNodeTraverser extends NodeTraverser
{
    public function __construct(MetadataNodeVisitor $metadataNodeVisitor)
    {
        // this would crash, since property is `null`
        foreach ($this->visitors ...) {
        }
        // ...
    }
}
```

Using `[]` as default value would prevent similar bugs.