### PR TITLE
StaticCall::$name cannot be a string

### DIFF
--- a/lib/PhpParser/Node/Expr/StaticCall.php
+++ b/lib/PhpParser/Node/Expr/StaticCall.php
@@ -10,7 +10,7 @@ class StaticCall extends Expr
 {
     /** @var Node\Name|Expr Class name */
     public $class;
-    /** @var string|Identifier|Expr Method name */
+    /** @var Identifier|Expr Method name */
     public $name;
     /** @var Node\Arg[] Arguments */
     public $args;


### PR DESCRIPTION
At least I don't *think* it can (the constructor definitely tries to prevent it being a string).