### PR TITLE
Document new `DONT_TRAVERSER_CURRENT_AND_CHILDREN` constant

### DIFF
--- a/doc/2_Usage_of_basic_components.markdown
+++ b/doc/2_Usage_of_basic_components.markdown
@@ -339,10 +339,8 @@ All four methods can either return the changed node or not return at all (i.e. `
 case the current node is not changed.
 
 The `enterNode()` method can additionally return the value `NodeTraverser::DONT_TRAVERSE_CHILDREN`,
-which instructs the traverser to skip all children of the current node.
-
-The `enterNode()` method can additionally return the value `NodeTraverser::DONT_TRAVERSER_CURRENT_AND_CHILDREN`
-to skip both traversal of child nodes, and prevent subsequent visitors from visiting the current node.
+which instructs the traverser to skip all children of the current node. To furthermore prevent subsequent
+visitors from visiting the current node, `NodeTraverser::DONT_TRAVERSE_CURRENT_AND_CHILDREN` can be used instead.
 
 The `leaveNode()` method can additionally return the value `NodeTraverser::REMOVE_NODE`, in which
 case the current node will be removed from the parent array. Furthermore it is possible to return

--- a/doc/2_Usage_of_basic_components.markdown
+++ b/doc/2_Usage_of_basic_components.markdown
@@ -341,6 +341,9 @@ case the current node is not changed.
 The `enterNode()` method can additionally return the value `NodeTraverser::DONT_TRAVERSE_CHILDREN`,
 which instructs the traverser to skip all children of the current node.
 
+The `enterNode()` method can additionally return the value `NodeTraverser::DONT_TRAVERSER_CURRENT_AND_CHILDREN`
+to skip both traversal of child nodes, and prevent subsequent visitors from visiting the current node.
+
 The `leaveNode()` method can additionally return the value `NodeTraverser::REMOVE_NODE`, in which
 case the current node will be removed from the parent array. Furthermore it is possible to return
 an array of nodes, which will be merged into the parent array at the offset of the current node.

--- a/doc/component/Walking_the_AST.markdown
+++ b/doc/component/Walking_the_AST.markdown
@@ -281,7 +281,7 @@ special enterNode/leaveNode return values:
 
  * If *any* visitor returns `DONT_TRAVERSE_CHILDREN`, the children will be skipped for *all*
    visitors.
-* If *any* visitor returns `DONT_TRAVERSER_CURRENT_AND_CHILDREN`, the children will be skipped for *all*
+ * If *any* visitor returns `DONT_TRAVERSER_CURRENT_AND_CHILDREN`, the children will be skipped for *all*
    visitors, and all *subsequent* visitors will not visit the current node.
  * If *any* visitor returns `STOP_TRAVERSAL`, traversal is stopped for *all* visitors.
  * If a visitor returns a replacement node, subsequent visitors will be passed the replacement node,

--- a/doc/component/Walking_the_AST.markdown
+++ b/doc/component/Walking_the_AST.markdown
@@ -281,6 +281,8 @@ special enterNode/leaveNode return values:
 
  * If *any* visitor returns `DONT_TRAVERSE_CHILDREN`, the children will be skipped for *all*
    visitors.
+* If *any* visitor returns `DONT_TRAVERSER_CURRENT_AND_CHILDREN`, the children will be skipped for *all*
+   visitors, and all *subsequent* visitors will not visit the current node.
  * If *any* visitor returns `STOP_TRAVERSAL`, traversal is stopped for *all* visitors.
  * If a visitor returns a replacement node, subsequent visitors will be passed the replacement node,
    not the original one.


### PR DESCRIPTION
This PR adds missed documentation for already merged https://github.com/nikic/PHP-Parser/pull/536