### PR TITLE
Exclude files and folders from release archive

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+/doc export-ignore
+/test export-ignore
+/test_old export-ignore
+/.gitignore export-ignore
+/.travis.yml export-ignore
+/phpunit.xml.dist export-ignore


### PR DESCRIPTION
Hi,

Let's not publish all those file.
`.gitattributes` can be used to exclude files from final archive that is downloaded by composer.


Read more
- https://madewithlove.be/gitattributes/
- https://alexbilbie.com/2012/11/exclude-objects-with-gitattributes/
- http://www.pixelite.co.nz/article/using-git-attributes-exclude-files-your-release/
