### PR TITLE
add trailingComma.test to prettyPrinter

### DIFF
--- a/test/code/prettyPrinter/expr/trailingComma.test
+++ b/test/code/prettyPrinter/expr/trailingComma.test
@@ -1,0 +1,10 @@
+Trailing comma
+-----
+<?php
+
+$items = [1, ];
+call_me(1, );
+-----
+!!php7
+$items = [1, ];
+call_me(1, );


### PR DESCRIPTION
Since PHP 7.3 adds trailing comma to function arguments, it would be great preserve them. Also in arrays.

I have idea how to use attribute to detect and print them, but I didn't find a way to detect "," in a grammar.

For arrays, I looked somewhere here:
https://github.com/nikic/PHP-Parser/blob/ba092652fe4abdb02863db6345ce0867839c20c9/grammar/php7.y#L970

For functions to `argument_list`:
https://github.com/nikic/PHP-Parser/blob/ba092652fe4abdb02863db6345ce0867839c20c9/grammar/php7.y#L770

But I always get just the result list of arguments, not original string.

Where should I look in a grammar?

