### PR TITLE
AA-0002 fixed the Call to undefined method PhpParser\Node\Expr\Variable::toString() issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@ vendor/
 composer.lock
 grammar/kmyacc.exe
 grammar/y.output
-.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ vendor/
 composer.lock
 grammar/kmyacc.exe
 grammar/y.output
+.idea/

--- a/lib/PhpParser/Node/Expr/Variable.php
+++ b/lib/PhpParser/Node/Expr/Variable.php
@@ -27,4 +27,13 @@ class Variable extends Expr
     public function getType() : string {
         return 'Expr_Variable';
     }
+
+    /**
+     * Get Variable as string.
+     *
+     * @return string Variable as string.
+     */
+    public function toString() : string {
+        return $this->name;
+    }
 }

--- a/lib/PhpParser/Node/Expr/Variable.php
+++ b/lib/PhpParser/Node/Expr/Variable.php
@@ -27,13 +27,4 @@ class Variable extends Expr
     public function getType() : string {
         return 'Expr_Variable';
     }
-
-    /**
-     * Get Variable as string.
-     *
-     * @return string Variable as string.
-     */
-    public function toString() : string {
-        return $this->name;
-    }
 }


### PR DESCRIPTION
got this issue :
[Error] Call to undefined method PhpParser\Node\Expr\Variable::toString()

while running some tests using AspectMock caused by this line:

https://github.com/goaop/framework/blob/72521d026692131f4052c1d7b3dad15c846cdd0f/src/Instrument/Transformer/MagicConstantTransformer.php#L94


