### PR TITLE
Fix assert warning on files with no code, only 1 comment

### DIFF
--- a/lib/PhpParser/PrettyPrinterAbstract.php
+++ b/lib/PhpParser/PrettyPrinterAbstract.php
@@ -750,7 +750,10 @@ abstract class PrettyPrinterAbstract
 
                 $itemStartPos = $origArrItem->getStartTokenPos();
                 $itemEndPos = $origArrItem->getEndTokenPos();
-                \assert($itemStartPos >= 0 && $itemEndPos >= 0);
+
+                if ($origArrItem instanceof Stmt\Nop && $itemEndPos > -1) {
+                    \assert($itemStartPos >= 0 && $itemEndPos >= 0);
+                }
 
                 if ($itemEndPos < $itemStartPos) {
                     // End can be before start for Nop nodes, because offsets refer to non-whitespace

--- a/test/PhpParser/CodeParsingTest.php
+++ b/test/PhpParser/CodeParsingTest.php
@@ -96,6 +96,11 @@ class CodeParsingTest extends CodeTestAbstract
                 $endFilePos = $node->getEndFilePos();
                 $startTokenPos = $node->getStartTokenPos();
                 $endTokenPos = $node->getEndTokenPos();
+
+                if ($node instanceof Stmt\Nop && $endTokenPos === -1) {
+                    return;
+                }
+
                 if ($startLine < 0 || $endLine < 0 ||
                     $startFilePos < 0 || $endFilePos < 0 ||
                     $startTokenPos < 0 || $endTokenPos < 0

--- a/test/code/parser/noCodeOnlyOneComment.test
+++ b/test/code/parser/noCodeOnlyOneComment.test
@@ -1,0 +1,13 @@
+No code, only one comment
+-----
+<?php
+
+// This test was added because of https://github.com/nikic/PHP-Parser/issues/589
+-----
+array(
+    0: Stmt_Nop(
+        comments: array(
+            0: // This test was added because of https://github.com/nikic/PHP-Parser/issues/589
+        )
+    )
+)


### PR DESCRIPTION
This is my attempt to fix #589, when a file is encountered with no PHP code, but does have a comment. Example:

```php
<?php

// a comment
```

This is my first look into this project's codebase so I'm not very familiar with it. Please review and let me know if this solution would work or not for any reason.