### PR TITLE
Enable PHP zend.assertions on Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,9 @@ matrix:
     - php: nightly
   fast_finish: true
 
+before_script:
+    - phpenv config-add travis.php.ini
+
 script:
   - if [ $TRAVIS_PHP_VERSION = '7.0' ]; then vendor/bin/phpunit --coverage-clover build/logs/clover.xml; else vendor/bin/phpunit; fi
   - if [ $TRAVIS_PHP_VERSION = '7.2' ]; then test_old/run-php-src.sh; fi

--- a/travis.php.ini
+++ b/travis.php.ini
@@ -1,0 +1,1 @@
+zend.assertions = 1


### PR DESCRIPTION
This project makes use of PHP's `assert()`, so this enables the php.ini directive during Travis builds.