### PR TITLE
Resolve return type of arrow functions

### DIFF
--- a/lib/PhpParser/NodeVisitor/NameResolver.php
+++ b/lib/PhpParser/NodeVisitor/NameResolver.php
@@ -91,6 +91,7 @@ class NameResolver extends NodeVisitorAbstract
             $this->resolveSignature($node);
         } elseif ($node instanceof Stmt\ClassMethod
                   || $node instanceof Expr\Closure
+                  || $node instanceof Expr\ArrowFunction
         ) {
             $this->resolveSignature($node);
         } elseif ($node instanceof Stmt\Property) {

--- a/test/PhpParser/NodeVisitor/NameResolverTest.php
+++ b/test/PhpParser/NodeVisitor/NameResolverTest.php
@@ -219,6 +219,8 @@ function(A $a) : A {};
 function fn3(?A $a) : ?A {}
 function fn4(?array $a) : ?array {}
 
+fn(?A $a): ?A => $a;
+
 A::b();
 A::$b;
 A::B;
@@ -263,6 +265,7 @@ function fn3(?\NS\A $a) : ?\NS\A
 function fn4(?array $a) : ?array
 {
 }
+fn(?\NS\A $a): ?\NS\A => $a;
 \NS\A::b();
 \NS\A::$b;
 \NS\A::B;

--- a/test/PhpParser/NodeVisitor/NameResolverTest.php
+++ b/test/PhpParser/NodeVisitor/NameResolverTest.php
@@ -219,6 +219,8 @@ function(A $a) : A {};
 function fn3(?A $a) : ?A {}
 function fn4(?array $a) : ?array {}
 
+fn(array $a): array => $a;
+fn(A $a): A => $a;
 fn(?A $a): ?A => $a;
 
 A::b();
@@ -265,6 +267,8 @@ function fn3(?\NS\A $a) : ?\NS\A
 function fn4(?array $a) : ?array
 {
 }
+fn(array $a): array => $a;
+fn(\NS\A $a): \NS\A => $a;
 fn(?\NS\A $a): ?\NS\A => $a;
 \NS\A::b();
 \NS\A::$b;


### PR DESCRIPTION
The NameResolver is currently not working with the re newly introduced ArrowFunction node of PHP 7.4 in the 4.2.2 release. This line of code fixes the issue.