### PR TITLE
Improve printer compatibility with PSR-2/12

### DIFF
--- a/lib/PhpParser/PrettyPrinter/Standard.php
+++ b/lib/PhpParser/PrettyPrinter/Standard.php
@@ -584,8 +584,8 @@ class Standard extends PrettyPrinterAbstract
         return ($node->static ? 'static ' : '')
              . 'function ' . ($node->byRef ? '&' : '')
              . '(' . $this->pCommaSeparated($node->params) . ')'
-             . (!empty($node->uses) ? ' use(' . $this->pCommaSeparated($node->uses) . ')' : '')
-             . (null !== $node->returnType ? ' : ' . $this->p($node->returnType) : '')
+             . (!empty($node->uses) ? ' use (' . $this->pCommaSeparated($node->uses) . ')' : '')
+             . (null !== $node->returnType ? ': ' . $this->p($node->returnType) : '')
              . ' {' . $this->pStmts($node->stmts) . $this->nl . '}';
     }
 
@@ -722,7 +722,7 @@ class Standard extends PrettyPrinterAbstract
         return $this->pModifiers($node->flags)
              . 'function ' . ($node->byRef ? '&' : '') . $node->name
              . '(' . $this->pCommaSeparated($node->params) . ')'
-             . (null !== $node->returnType ? ' : ' . $this->p($node->returnType) : '')
+             . (null !== $node->returnType ? ': ' . $this->p($node->returnType) : '')
              . (null !== $node->stmts
                 ? $this->nl . '{' . $this->pStmts($node->stmts) . $this->nl . '}'
                 : ';');

--- a/lib/PhpParser/PrettyPrinter/Standard.php
+++ b/lib/PhpParser/PrettyPrinter/Standard.php
@@ -736,7 +736,7 @@ class Standard extends PrettyPrinterAbstract
     protected function pStmt_Function(Stmt\Function_ $node) {
         return 'function ' . ($node->byRef ? '&' : '') . $node->name
              . '(' . $this->pCommaSeparated($node->params) . ')'
-             . (null !== $node->returnType ? ' : ' . $this->p($node->returnType) : '')
+             . (null !== $node->returnType ? ': ' . $this->p($node->returnType) : '')
              . $this->nl . '{' . $this->pStmts($node->stmts) . $this->nl . '}';
     }
 

--- a/test/PhpParser/NodeVisitor/NameResolverTest.php
+++ b/test/PhpParser/NodeVisitor/NameResolverTest.php
@@ -209,15 +209,15 @@ class A extends B implements C, D {
 }
 
 interface A extends C, D {
-    public function a(A $a) : A;
+    public function a(A $a): A;
 }
 
-function f(A $a) : A {}
-function f2(array $a) : array {}
-function(A $a) : A {};
+function f(A $a): A {}
+function f2(array $a): array {}
+function(A $a): A {};
 
-function fn3(?A $a) : ?A {}
-function fn4(?array $a) : ?array {}
+function fn3(?A $a): ?A {}
+function fn4(?array $a): ?array {}
 
 fn(array $a): array => $a;
 fn(A $a): A => $a;
@@ -251,20 +251,20 @@ class A extends \NS\B implements \NS\C, \NS\D
 }
 interface A extends \NS\C, \NS\D
 {
-    public function a(\NS\A $a) : \NS\A;
+    public function a(\NS\A $a): \NS\A;
 }
-function f(\NS\A $a) : \NS\A
+function f(\NS\A $a): \NS\A
 {
 }
-function f2(array $a) : array
+function f2(array $a): array
 {
 }
-function (\NS\A $a) : \NS\A {
+function (\NS\A $a): \NS\A {
 };
-function fn3(?\NS\A $a) : ?\NS\A
+function fn3(?\NS\A $a): ?\NS\A
 {
 }
-function fn4(?array $a) : ?array
+function fn4(?array $a): ?array
 {
 }
 fn(array $a): array => $a;

--- a/test/code/prettyPrinter/expr/closure.test
+++ b/test/code/prettyPrinter/expr/closure.test
@@ -6,13 +6,13 @@ $closureWithArgs = function ($arg1, $arg2) {
     $comment = 'closure body';
 };
 
-$closureWithArgsAndVars = function ($arg1, $arg2) use($var1, $var2) {
+$closureWithArgsAndVars = function ($arg1, $arg2) use ($var1, $var2) {
     $comment = 'closure body';
 };
 -----
 $closureWithArgs = function ($arg1, $arg2) {
     $comment = 'closure body';
 };
-$closureWithArgsAndVars = function ($arg1, $arg2) use($var1, $var2) {
+$closureWithArgsAndVars = function ($arg1, $arg2) use ($var1, $var2) {
     $comment = 'closure body';
 };

--- a/test/code/prettyPrinter/stmt/function_signatures.test
+++ b/test/code/prettyPrinter/stmt/function_signatures.test
@@ -17,9 +17,9 @@ interface A
     function f10(A ...$a);
     function f11(A &$a);
     function f12(A &...$a);
-    function f13($a) : array;
-    function f14($a) : callable;
-    function f15($a) : B\C;
+    function f13($a): array;
+    function f14($a): callable;
+    function f15($a): B\C;
 }
 -----
 interface A
@@ -37,7 +37,7 @@ interface A
     function f10(A ...$a);
     function f11(A &$a);
     function f12(A &...$a);
-    function f13($a) : array;
-    function f14($a) : callable;
-    function f15($a) : B\C;
+    function f13($a): array;
+    function f14($a): callable;
+    function f15($a): B\C;
 }

--- a/test/code/prettyPrinter/stmt/nullable_types.test
+++ b/test/code/prettyPrinter/stmt/nullable_types.test
@@ -1,11 +1,11 @@
 Nullable types
 -----
 <?php
-function test(?Foo $bar, ?string $foo, ?\Xyz $zyx) : ?Baz
+function test(?Foo $bar, ?string $foo, ?\Xyz $zyx): ?Baz
 {
 }
 -----
 !!php7
-function test(?Foo $bar, ?string $foo, ?\Xyz $zyx) : ?Baz
+function test(?Foo $bar, ?string $foo, ?\Xyz $zyx): ?Baz
 {
 }


### PR DESCRIPTION
## Fixed whitespace before Closure "use" statement.

Before:
```php
function ($arg) use($var) { ... }
```

After:
```php
function ($arg) use ($var) { ... }
//                 ^ whitespace added
```

Reason: PSR-2 https://www.php-fig.org/psr/psr-2/#6-closures

## Removed whitespace prefix before typehint colon.

Before:
```php
function example() : void { ... }
```

After:
```php
function example(): void { ... }
//                ^ whitespace removed
```

Reason: PSR-12 https://github.com/php-fig/fig-standards/blob/master/proposed/extended-coding-style-guide.md#45-method-and-function-arguments