### PR TITLE
add getProperties() to Class_/Trait_ and getConstants() to Class_/Interface_

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ vendor/
 composer.lock
 grammar/kmyacc.exe
 grammar/y.output
+.phpunit.result.cache

--- a/lib/PhpParser/Node/Stmt/ClassLike.php
+++ b/lib/PhpParser/Node/Stmt/ClassLike.php
@@ -15,6 +15,32 @@ abstract class ClassLike extends Node\Stmt
     public $stmts;
 
     /**
+     * @return ClassConst[]
+     */
+    public function getConstants() : array {
+        $constants = [];
+        foreach ($this->stmts as $stmt) {
+            if ($stmt instanceof ClassConst) {
+                $constants[] = $stmt;
+            }
+        }
+        return $constants;
+    }
+
+    /**
+     * @return Property[]
+     */
+    public function getProperties() : array {
+        $properties = [];
+        foreach ($this->stmts as $stmt) {
+            if ($stmt instanceof Property) {
+                $properties[] = $stmt;
+            }
+        }
+        return $properties;
+    }
+
+    /**
      * Gets all methods defined directly in this class/interface/trait
      *
      * @return ClassMethod[]

--- a/lib/PhpParser/Node/Stmt/Class_.php
+++ b/lib/PhpParser/Node/Stmt/Class_.php
@@ -98,7 +98,7 @@ class Class_ extends ClassLike
             throw new Error('Cannot use the final modifier on an abstract class member');
         }
     }
-    
+
     public function getType() : string {
         return 'Stmt_Class';
     }

--- a/lib/PhpParser/Node/Stmt/Interface_.php
+++ b/lib/PhpParser/Node/Stmt/Interface_.php
@@ -28,7 +28,7 @@ class Interface_ extends ClassLike
     public function getSubNodeNames() : array {
         return ['name', 'extends', 'stmts'];
     }
-    
+
     public function getType() : string {
         return 'Stmt_Interface';
     }

--- a/lib/PhpParser/Node/Stmt/Trait_.php
+++ b/lib/PhpParser/Node/Stmt/Trait_.php
@@ -23,7 +23,7 @@ class Trait_ extends ClassLike
     public function getSubNodeNames() : array {
         return ['name', 'stmts'];
     }
-    
+
     public function getType() : string {
         return 'Stmt_Trait';
     }

--- a/test/PhpParser/Builder/TraitTest.php
+++ b/test/PhpParser/Builder/TraitTest.php
@@ -5,6 +5,12 @@ namespace PhpParser\Builder;
 use PhpParser\Comment;
 use PhpParser\Node\Name;
 use PhpParser\Node\Stmt;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassConst;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Property;
+use PhpParser\Node\Stmt\PropertyProperty;
+use PhpParser\Node\Stmt\TraitUse;
 
 class TraitTest extends \PHPUnit\Framework\TestCase
 {
@@ -42,5 +48,44 @@ class TraitTest extends \PHPUnit\Framework\TestCase
         $this->createTraitBuilder('Test')
             ->addStmt(new Stmt\Echo_([]))
         ;
+    }
+
+    public function testGetMethods() {
+        $methods = [
+            new ClassMethod('foo'),
+            new ClassMethod('bar'),
+            new ClassMethod('fooBar'),
+        ];
+        $trait = new Stmt\Trait_('Foo', [
+            'stmts' => [
+                new TraitUse([]),
+                $methods[0],
+                new ClassConst([]),
+                $methods[1],
+                new Property(0, []),
+                $methods[2],
+            ]
+        ]);
+
+        $this->assertSame($methods, $trait->getMethods());
+    }
+
+    public function testGetProperties()
+    {
+        $properties = [
+            new Property(Class_::MODIFIER_PUBLIC, [new PropertyProperty('foo')]),
+            new Property(Class_::MODIFIER_PUBLIC, [new PropertyProperty('bar')]),
+        ];
+        $trait = new Stmt\Trait_('Foo', [
+            'stmts' => [
+                new TraitUse([]),
+                $properties[0],
+                new ClassConst([]),
+                $properties[1],
+                new ClassMethod('fooBar'),
+            ]
+        ]);
+
+        $this->assertSame($properties, $trait->getProperties());
     }
 }

--- a/test/PhpParser/Node/Stmt/ClassTest.php
+++ b/test/PhpParser/Node/Stmt/ClassTest.php
@@ -2,6 +2,8 @@
 
 namespace PhpParser\Node\Stmt;
 
+use PhpParser\Node\Scalar\String_;
+
 class ClassTest extends \PHPUnit\Framework\TestCase
 {
     public function testIsAbstract() {
@@ -38,6 +40,42 @@ class ClassTest extends \PHPUnit\Framework\TestCase
         ]);
 
         $this->assertSame($methods, $class->getMethods());
+    }
+
+    public function testGetConstants() {
+        $constants = [
+            new ClassConst([new \PhpParser\Node\Const_('foo', new String_('foo_value'))]),
+            new ClassConst([new \PhpParser\Node\Const_('bar', new String_('bar_value'))]),
+        ];
+        $class = new Class_('Foo', [
+            'stmts' => [
+                new TraitUse([]),
+                $constants[0],
+                new ClassMethod('fooBar'),
+                $constants[1],
+            ]
+        ]);
+
+        $this->assertSame($constants, $class->getConstants());
+    }
+
+    public function testGetProperties()
+    {
+        $properties = [
+            new Property(Class_::MODIFIER_PUBLIC, [new PropertyProperty('foo')]),
+            new Property(Class_::MODIFIER_PUBLIC, [new PropertyProperty('bar')]),
+        ];
+        $class = new Class_('Foo', [
+            'stmts' => [
+                new TraitUse([]),
+                $properties[0],
+                new ClassConst([]),
+                $properties[1],
+                new ClassMethod('fooBar'),
+            ]
+        ]);
+
+        $this->assertSame($properties, $class->getProperties());
     }
 
     public function testGetMethod() {

--- a/test/PhpParser/Node/Stmt/InterfaceTest.php
+++ b/test/PhpParser/Node/Stmt/InterfaceTest.php
@@ -3,6 +3,7 @@
 namespace PhpParser\Node\Stmt;
 
 use PhpParser\Node;
+use PhpParser\Node\Scalar\String_;
 
 class InterfaceTest extends \PHPUnit\Framework\TestCase
 {
@@ -11,7 +12,7 @@ class InterfaceTest extends \PHPUnit\Framework\TestCase
             new ClassMethod('foo'),
             new ClassMethod('bar'),
         ];
-        $interface = new Class_('Foo', [
+        $interface = new Interface_('Foo', [
             'stmts' => [
                 new Node\Stmt\ClassConst([new Node\Const_('C1', new Node\Scalar\String_('C1'))]),
                 $methods[0],
@@ -22,5 +23,22 @@ class InterfaceTest extends \PHPUnit\Framework\TestCase
         ]);
 
         $this->assertSame($methods, $interface->getMethods());
+    }
+
+    public function testGetConstants() {
+        $constants = [
+            new ClassConst([new \PhpParser\Node\Const_('foo', new String_('foo_value'))]),
+            new ClassConst([new \PhpParser\Node\Const_('bar', new String_('bar_value'))]),
+        ];
+        $class = new Interface_('Foo', [
+            'stmts' => [
+                new TraitUse([]),
+                $constants[0],
+                new ClassMethod('fooBar'),
+                $constants[1],
+            ]
+        ]);
+
+        $this->assertSame($constants, $class->getConstants());
     }
 }


### PR DESCRIPTION
As there is `getMethods()` at `ClassLike`, I often tend to use `getProperties()` and `getConstants()`, but there are none. I understood that's probably because only `getMethods()` is in `ClassLike` for all 3 sub-classes.

Yet the API is inconsistent and confusing. This would fix that.

```php
foreach ($class->stmts as $stmt) {
    if (! $stmt instanceof Property) {
        continue;
    }

    // do something
}   
```

vs.

```php
foreach ($class->getMethods() as $method) {
    // do something
}   
```

This keeps happening to me last 2 years so I finally do something about it