### PR TITLE
syntax error in BuilderFactory.php

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,8 @@ matrix:
   fast_finish: true
 
 script:
-  - if [ $TRAVIS_PHP_VERSION = '7.0' ]; then vendor/bin/phpunit --coverage-clover build/logs/clover.xml; else vendor/bin/phpunit; fi
-  - if [ $TRAVIS_PHP_VERSION = '7.2' ]; then test_old/run-php-src.sh; fi
+  - |
+    echo '<?php require "vendor/autoload.php"; $b=new PhpParser\BuilderFactory(); $b->class(DateTime::class);' > failingBuilderFactory.php
+    echo 'Expecting "PHP Parse error: syntax error" ...'
+    php failingBuilderFactory.php
 
-after_success:
-  - if [ $TRAVIS_PHP_VERSION = '7.0' ]; then php vendor/bin/coveralls; fi


### PR DESCRIPTION
What makes my php file fail?

```
$ php failingBuilderFactory.php
PHP Parse error:  syntax error, unexpected '\' (T_NS_SEPARATOR), expecting function (T_FUNCTION) or const (T_CONST) in /home/viktor/src/BrainMonkey/vendor/nikic/php-parser/lib/PhpParser/BuilderFactory.php on line 35
```

```
$ php -v
PHP 7.2.24-1+0~20191026.31+debian9~1.gbpbbacde (cli) (built: Oct 26 2019 14:18:28) ( NTS )
Copyright (c) 1997-2018 The PHP Group
Zend Engine v3.2.0, Copyright (c) 1998-2018 Zend Technologies
    with Zend OPcache v7.2.24-1+0~20191026.31+debian9~1.gbpbbacde, Copyright (c) 1999-2018, by Zend Technologies
```