### PR TITLE
Add `getProperty` to `ClassLike`

### DIFF
--- a/lib/PhpParser/Node/Stmt/ClassLike.php
+++ b/lib/PhpParser/Node/Stmt/ClassLike.php
@@ -54,6 +54,26 @@ abstract class ClassLike extends Node\Stmt
     }
 
     /**
+     * Gets property with the given name defined directly in this class/interface/trait.
+     *
+     * @param string $name Name of the property
+     *
+     * @return Property|null Property node or null if the property does not exist
+     */
+    public function getProperty(string $name) {
+        foreach ($this->stmts as $stmt) {
+            if ($stmt instanceof Property) {
+                foreach ($stmt->props as $prop) {
+                    if ($prop instanceof PropertyProperty && $name === $prop->name->toString()) {
+                        return $stmt;
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
      * Gets all methods defined directly in this class/interface/trait
      *
      * @return ClassMethod[]

--- a/test/PhpParser/Node/Stmt/ClassTest.php
+++ b/test/PhpParser/Node/Stmt/ClassTest.php
@@ -94,6 +94,31 @@ class ClassTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($properties, $class->getProperties());
     }
 
+    public function testGetProperty() {
+        $properties = [
+            $fooProp = new Property(Class_::MODIFIER_PUBLIC, [new PropertyProperty('foo1')]),
+            $barProp = new Property(Class_::MODIFIER_PUBLIC, [new PropertyProperty('BAR1')]),
+            $fooBarProp = new Property(Class_::MODIFIER_PUBLIC, [new PropertyProperty('foo2'), new PropertyProperty('bar2')]),
+        ];
+        $class = new Class_('Foo', [
+            'stmts' => [
+                new TraitUse([]),
+                $properties[0],
+                new ClassConst([]),
+                $properties[1],
+                new ClassMethod('fooBar'),
+                $properties[2],
+            ]
+        ]);
+
+        $this->assertSame($fooProp, $class->getProperty('foo1'));
+        $this->assertSame($barProp, $class->getProperty('BAR1'));
+        $this->assertSame($fooBarProp, $class->getProperty('foo2'));
+        $this->assertSame($fooBarProp, $class->getProperty('bar2'));
+        $this->assertNull($class->getProperty('bar1'));
+        $this->assertNull($class->getProperty('nonExisting'));
+    }
+
     public function testGetMethod() {
         $methodConstruct = new ClassMethod('__CONSTRUCT');
         $methodTest = new ClassMethod('test');


### PR DESCRIPTION
This makes it easier to get a property by name from a ClassLike. 