### PR TITLE
add psalm types

### DIFF
--- a/lib/PhpParser/Comment.php
+++ b/lib/PhpParser/Comment.php
@@ -147,7 +147,7 @@ class Comment implements \JsonSerializable
      * without trailing whitespace on the first line, but with trailing whitespace
      * on all subsequent lines.
      *
-     * @return mixed|string
+     * @return string
      */
     public function getReformattedText() {
         $text = trim($this->text);

--- a/lib/PhpParser/ConstExprEvaluator.php
+++ b/lib/PhpParser/ConstExprEvaluator.php
@@ -57,7 +57,7 @@ class ConstExprEvaluator
      * See class doc comment for caveats and limitations.
      *
      * @param Expr $expr Constant expression to evaluate
-     * @return mixed Result of evaluation
+     * @return float|string|int|array|bool Result of evaluation
      *
      * @throws ConstExprEvaluationException if the expression cannot be evaluated or an error occurred
      */
@@ -92,7 +92,7 @@ class ConstExprEvaluator
      * See class doc comment for caveats and limitations.
      *
      * @param Expr $expr Constant expression to evaluate
-     * @return mixed Result of evaluation
+     * @return float|string|int|array|bool Result of evaluation
      *
      * @throws ConstExprEvaluationException if the expression cannot be evaluated
      */
@@ -100,6 +100,11 @@ class ConstExprEvaluator
         return $this->evaluate($expr);
     }
 
+    /**
+     * @param Expr $expr
+     * @return float|string|int|array|bool
+     * @throws \Exception
+     */
     private function evaluate(Expr $expr) {
         if ($expr instanceof Scalar\LNumber
             || $expr instanceof Scalar\DNumber
@@ -157,6 +162,11 @@ class ConstExprEvaluator
         return $array;
     }
 
+    /**
+     * @param Expr\Ternary $expr
+     * @return array|bool|float|int|string
+     * @throws \Exception
+     */
     private function evaluateTernary(Expr\Ternary $expr) {
         if (null === $expr->if) {
             return $this->evaluate($expr->cond) ?: $this->evaluate($expr->else);
@@ -167,6 +177,11 @@ class ConstExprEvaluator
             : $this->evaluate($expr->else);
     }
 
+    /**
+     * @param Expr\BinaryOp $expr
+     * @return int|bool|array|string|float
+     * @throws \Exception
+     */
     private function evaluateBinaryOp(Expr\BinaryOp $expr) {
         if ($expr instanceof Expr\BinaryOp\Coalesce
             && $expr->left instanceof Expr\ArrayDimFetch

--- a/lib/PhpParser/Error.php
+++ b/lib/PhpParser/Error.php
@@ -54,7 +54,7 @@ class Error extends \RuntimeException
     /**
      * Gets the attributes of the node/token the error occurred at.
      *
-     * @return array
+     * @return array<string, mixed>
      */
     public function getAttributes() : array {
         return $this->attributes;
@@ -63,7 +63,7 @@ class Error extends \RuntimeException
     /**
      * Sets the attributes of the node/token the error occurred at.
      *
-     * @param array $attributes
+     * @param array<string, mixed> $attributes
      */
     public function setAttributes(array $attributes) {
         $this->attributes = $attributes;

--- a/lib/PhpParser/JsonDecoder.php
+++ b/lib/PhpParser/JsonDecoder.php
@@ -87,6 +87,11 @@ class JsonDecoder
         return $this->reflectionClassCache[$nodeType];
     }
 
+    /**
+     * @param string $nodeType
+     * @return string
+     * @psalm-return class-string
+     */
     private function classNameFromNodeType(string $nodeType) : string {
         $className = 'PhpParser\\Node\\' . strtr($nodeType, '_', '\\');
         if (class_exists($className)) {

--- a/lib/PhpParser/Lexer.php
+++ b/lib/PhpParser/Lexer.php
@@ -345,6 +345,7 @@ class Lexer
      * attributes are against this token array.
      *
      * @return array Array of tokens in token_get_all() format
+     * @psalm-return array<int,string|array{0:int,1:string,2:int}>
      */
     public function getTokens() : array {
         return $this->tokens;
@@ -380,7 +381,7 @@ class Lexer
      * to the identifiers used by the Parser. Additionally it
      * maps T_OPEN_TAG_WITH_ECHO to T_ECHO and T_CLOSE_TAG to ';'.
      *
-     * @return array The token map
+     * @return array<int, int> The token map
      */
     protected function createTokenMap() : array {
         $tokenMap = [];

--- a/lib/PhpParser/NameContext.php
+++ b/lib/PhpParser/NameContext.php
@@ -153,6 +153,7 @@ class NameContext
      * @param int    $type One of Stmt\Use_::TYPE_*
      *
      * @return Name[] Possible representations of the name
+     * @psalm-return non-empty-list<Name>
      */
     public function getPossibleNames(string $name, int $type) : array {
         $lcName = strtolower($name);

--- a/lib/PhpParser/Node.php
+++ b/lib/PhpParser/Node.php
@@ -14,7 +14,8 @@ interface Node
     /**
      * Gets the names of the sub nodes.
      *
-     * @return array Names of sub nodes
+     * @return string[] Names of sub nodes
+     * @psalm-return list<string>
      */
     public function getSubNodeNames() : array;
 
@@ -138,14 +139,14 @@ interface Node
     /**
      * Returns all the attributes of this node.
      *
-     * @return array
+     * @return array<string, mixed>
      */
     public function getAttributes() : array;
 
     /**
      * Replaces all the attributes of this node.
      *
-     * @param array $attributes
+     * @param array<string, mixed> $attributes
      */
     public function setAttributes(array $attributes);
 }

--- a/lib/PhpParser/Node/Expr/Closure.php
+++ b/lib/PhpParser/Node/Expr/Closure.php
@@ -12,7 +12,10 @@ class Closure extends Expr implements FunctionLike
     public $static;
     /** @var bool Whether to return by reference */
     public $byRef;
-    /** @var Node\Param[] Parameters */
+    /**
+     * @var Node\Param[] Parameters
+     * @psalm-var list<Node\Param>
+     */
     public $params;
     /** @var ClosureUse[] use()s */
     public $uses;

--- a/lib/PhpParser/Node/Stmt/ClassConst.php
+++ b/lib/PhpParser/Node/Stmt/ClassConst.php
@@ -10,16 +10,16 @@ class ClassConst extends Node\Stmt
     public $flags;
     /** 
      * @var Node\Const_[] Constant declarations
-     * @psalm-var list<Node\Const>
+     * @psalm-var list<Node\Const_>
      */
     public $consts;
 
     /**
      * Constructs a class const list node.
      *
-     * @param Node\Const_[] $consts     Constant declarations
-     * @param int           $flags      Modifiers
-     * @param array         $attributes Additional attributes
+     * @param list<Node\Const_> $consts     Constant declarations
+     * @param int               $flags      Modifiers
+     * @param array             $attributes Additional attributes
      */
     public function __construct(array $consts, int $flags = 0, array $attributes = []) {
         $this->attributes = $attributes;

--- a/lib/PhpParser/Node/Stmt/ClassConst.php
+++ b/lib/PhpParser/Node/Stmt/ClassConst.php
@@ -8,7 +8,10 @@ class ClassConst extends Node\Stmt
 {
     /** @var int Modifiers */
     public $flags;
-    /** @var Node\Const_[] Constant declarations */
+    /** 
+     * @var Node\Const_[] Constant declarations
+     * @psalm-var list<Node\Const>
+     */
     public $consts;
 
     /**

--- a/lib/PhpParser/Node/Stmt/ClassMethod.php
+++ b/lib/PhpParser/Node/Stmt/ClassMethod.php
@@ -13,7 +13,10 @@ class ClassMethod extends Node\Stmt implements FunctionLike
     public $byRef;
     /** @var Node\Identifier Name */
     public $name;
-    /** @var Node\Param[] Parameters */
+    /**
+     * @var Node\Param[] Parameters
+     * @psalm-var list<Node\Param>
+     */
     public $params;
     /** @var null|Node\Identifier|Node\Name|Node\NullableType|Node\UnionType Return type */
     public $returnType;

--- a/lib/PhpParser/Node/Stmt/Function_.php
+++ b/lib/PhpParser/Node/Stmt/Function_.php
@@ -14,7 +14,10 @@ class Function_ extends Node\Stmt implements FunctionLike
     public $byRef;
     /** @var Node\Identifier Name */
     public $name;
-    /** @var Node\Param[] Parameters */
+    /**
+     * @var Node\Param[] Parameters
+     * @psalm-var list<Node\Param>
+     */
     public $params;
     /** @var null|Node\Identifier|Node\Name|Node\NullableType|Node\UnionType Return type */
     public $returnType;

--- a/lib/PhpParser/Node/Stmt/Namespace_.php
+++ b/lib/PhpParser/Node/Stmt/Namespace_.php
@@ -12,7 +12,7 @@ class Namespace_ extends Node\Stmt
 
     /** @var null|Node\Name Name */
     public $name;
-    /** @var Node\Stmt[] Statements */
+    /** @var null|Node\Stmt[] Statements */
     public $stmts;
 
     /**

--- a/lib/PhpParser/NodeAbstract.php
+++ b/lib/PhpParser/NodeAbstract.php
@@ -9,7 +9,7 @@ abstract class NodeAbstract implements Node, \JsonSerializable
     /**
      * Creates a Node.
      *
-     * @param array $attributes Array of attributes
+     * @param array<string, mixed> $attributes Array of attributes
      */
     public function __construct(array $attributes = []) {
         $this->attributes = $attributes;
@@ -170,7 +170,7 @@ abstract class NodeAbstract implements Node, \JsonSerializable
     }
 
     /**
-     * @return array
+     * @return array<string, mixed>
      */
     public function jsonSerialize() : array {
         return ['nodeType' => $this->getType()] + get_object_vars($this);

--- a/lib/PhpParser/ParserAbstract.php
+++ b/lib/PhpParser/ParserAbstract.php
@@ -845,7 +845,7 @@ abstract class ParserAbstract implements Parser
      * Create attributes for a zero-length common-capturing nop.
      *
      * @param Comment[] $comments
-     * @return array
+     * @return array<string, mixed>
      */
     protected function createCommentNopAttributes(array $comments) {
         $comment = $comments[count($comments) - 1];

--- a/lib/PhpParser/ParserAbstract.php
+++ b/lib/PhpParser/ParserAbstract.php
@@ -53,7 +53,10 @@ abstract class ParserAbstract implements Parser
 
     /** @var int[] Map of lexer tokens to internal symbols */
     protected $tokenToSymbol;
-    /** @var string[] Map of symbols to their names */
+    /**
+     * @var string[] Map of symbols to their names
+     * @psalm-var list<string>
+     */
     protected $symbolToName;
     /** @var array Names of the production rules (only necessary for debugging) */
     protected $productions;

--- a/lib/PhpParser/PrettyPrinter/Standard.php
+++ b/lib/PhpParser/PrettyPrinter/Standard.php
@@ -449,6 +449,7 @@ class Standard extends PrettyPrinterAbstract
 
     protected function pExpr_Cast_Double(Cast\Double $node) {
         $kind = $node->getAttribute('kind', Cast\Double::KIND_DOUBLE);
+        $cast = '';
         if ($kind === Cast\Double::KIND_DOUBLE) {
             $cast = '(double)';
         } elseif ($kind === Cast\Double::KIND_FLOAT) {

--- a/lib/PhpParser/PrettyPrinterAbstract.php
+++ b/lib/PhpParser/PrettyPrinterAbstract.php
@@ -102,7 +102,7 @@ abstract class PrettyPrinterAbstract
     /** @var array Pretty printer options */
     protected $options;
 
-    /** @var TokenStream Original tokens for use in format-preserving pretty print */
+    /** @var TokenStream|null Original tokens for use in format-preserving pretty print */
     protected $origTokens;
     /** @var Internal\Differ Differ for node lists */
     protected $nodeListDiffer;
@@ -114,9 +114,10 @@ abstract class PrettyPrinterAbstract
      */
     protected $fixupMap;
     /**
-     * @var int[][] Map from "{$node->getType()}->{$subNode}" to ['left' => $l, 'right' => $r],
-     *              where $l and $r specify the token type that needs to be stripped when removing
-     *              this node.
+     * @psalm-var array<string, array<string, int|string>>
+     * @var (string|int)[][] Map from "{$node->getType()}->{$subNode}" to ['left' => $l, 'right' => $r],
+     *                       where $l and $r specify the token type that needs to be stripped when removing
+     *                       this node.
      */
     protected $removalMap;
     /**

--- a/lib/PhpParser/PrettyPrinterAbstract.php
+++ b/lib/PhpParser/PrettyPrinterAbstract.php
@@ -399,6 +399,8 @@ abstract class PrettyPrinterAbstract
      *
      * @param Node[] $nodes Array of Nodes to be printed
      *
+     * @psalm-param list<Node> $nodes
+     *
      * @return string Comma separated pretty printed nodes
      */
     protected function pCommaSeparated(array $nodes) : string {


### PR DESCRIPTION
Hi,

Working on https://github.com/Roave/BetterReflection/issues/525, I needed to refine some types in PHP-Parser.

I tried to either keep readable annotations for IDE like PHPStorm or add a @psalm- annotation.

I take the opportunity to thank you for all the good you did to PHP !