### PR TITLE
Failing test case for syntax error when Nop is only  class method statement

### DIFF
--- a/test/code/formatPreservation/classMethodNop.test
+++ b/test/code/formatPreservation/classMethodNop.test
@@ -1,0 +1,20 @@
+Adding statement to Class Method containing Nop
+-----
+<?php
+class Foo {
+    public function __construct()
+    {
+        // I'm just a comment
+    }
+}
+-----
+$stmts[0]->stmts[0]->stmts[] = new Stmt\Expression(new Node\Expr\Variable('foo'));
+-----
+<?php
+class Foo {
+    public function __construct()
+    {
+        // I'm just a comment
+        $foo;
+    }
+}


### PR DESCRIPTION
Hi there!

Thanks again for such a useful library :). We very *rarely* find issues... even though this lib does a lot of crazy stuff!

On symfony/maker-bundle#536, we stumbled upon a minor issue, which this test reproduces. The failed result is:

```diff
--- Expected
+++ Actual
@@ @@
 '<?php
 class Foo {
-    public function __construct()
+    public function __construct
+    $foo;()
     {
         // I'm just a comment
-        $foo;
     }
 }'
```

As you can see, for some reason, when the only statement is `Nop`, an appended statement is placed in the wrong location. If you try to *replace* the `Nop` statement with the new one (instead of appending to `->stmts`), it has no effect - the final source code matches the original.

I'm not sure where to look in the library for a fix - so apologies for sending an incomplete pull request.

Cheers!