### PR TITLE
Fix up tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,16 +26,18 @@ matrix:
       php: nightly
       install:
         - composer update --ignore-platform-req=php --no-progress --prefer-dist
-    - name: PHP 7 Integration Tests
-      php: 7.4
+    - name: PHP 7.3 Code on PHP 8.0 Integration Tests
+      php: nightly
+      install:
+        - composer update --ignore-platform-req=php --no-progress --prefer-dist
       script:
-        - test_old/run-php-src.sh 7
-    - name: PHP 8 Integration Tests
-      php: 7.4
+        - test_old/run-php-src.sh 7.3.21
+    - name: PHP 8.0 Code on PHP 7.0 Integration Tests
+      php: 7.0
       script:
-        - test_old/run-php-src.sh 8
+        - test_old/run-php-src.sh 8.0.0beta1
   allow_failures:
-    - name: PHP 8 Integration Tests
+    - name: PHP 8.0 Code on PHP 7.0 Integration Tests
   fast_finish: true
 
 script: vendor/bin/phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,6 @@ matrix:
     - name: PHP 8.0 Unit Tests
       php: nightly
       install:
-        - composer require phpunit/phpunit:^9.3 --dev --no-update
         - composer update --ignore-platform-req=php --no-progress --prefer-dist
     - name: PHP 7 Integration Tests
       php: 7.4
@@ -36,7 +35,6 @@ matrix:
       script:
         - test_old/run-php-src.sh 8
   allow_failures:
-    - name: PHP 8.0 Unit Tests
     - name: PHP 8 Integration Tests
   fast_finish: true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,35 +1,45 @@
 language: php
 dist: xenial
 
-cache:
-  directories:
-    - $HOME/.composer/cache
+before_install: composer self-update --2
 
-php:
-  - 7.0
-  - 7.1
-  - 7.2
-  - 7.3
-  - 7.4
-  - nightly
-
-install:
-  - if [ $TRAVIS_PHP_VERSION = '7.0' ]; then composer require satooshi/php-coveralls '~1.0'; fi
-  - |
-    if [ $TRAVIS_PHP_VERSION = 'nightly' ]; then
-      composer install --prefer-dist --ignore-platform-reqs;
-    else
-      composer install --prefer-dist;
-    fi
+install: composer update --no-progress --prefer-dist
 
 matrix:
+  include:
+    - name: PHP 7.0 Unit Tests
+      php: 7.0
+      install:
+        - composer require php-coveralls/php-coveralls:^2.2 --dev --no-update
+        - composer update --no-progress --prefer-dist
+      script: vendor/bin/phpunit --coverage-clover build/logs/clover.xml
+      after_success: php vendor/bin/coveralls
+    - name: PHP 7.1 Unit Tests
+      php: 7.1
+    - name: PHP 7.2 Unit Tests
+      php: 7.2
+    - name: PHP 7.3 Unit Tests
+      php: 7.3
+    - name: PHP 7.4 Unit Tests
+      php: 7.4
+    - name: PHP 8.0 Unit Tests
+      php: nightly
+      install:
+        - composer config minimum-stability dev
+        - composer config prefer-stable true
+        - composer require phpunit/phpunit:^9.3 --dev --no-update
+        - composer update --ignore-platform-req=php --no-progress --prefer-dist
+    - name: PHP 7 Integration Tests
+      php: 7.4
+      script:
+        - test_old/run-php-src.sh 7
+    - name: PHP 8 Integration Tests
+      php: 7.4
+      script:
+        - test_old/run-php-src.sh 8
   allow_failures:
-    - php: nightly
+    - name: PHP 8.0 Unit Tests
+    - name: PHP 8 Integration Tests
   fast_finish: true
 
-script:
-  - if [ $TRAVIS_PHP_VERSION = '7.0' ]; then vendor/bin/phpunit --coverage-clover build/logs/clover.xml; else vendor/bin/phpunit; fi
-  - if [ $TRAVIS_PHP_VERSION = '7.2' ]; then test_old/run-php-src.sh; fi
-
-after_success:
-  - if [ $TRAVIS_PHP_VERSION = '7.0' ]; then php vendor/bin/coveralls; fi
+script: vendor/bin/phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,6 @@ matrix:
     - name: PHP 8.0 Unit Tests
       php: nightly
       install:
-        - composer config minimum-stability dev
-        - composer config prefer-stable true
         - composer require phpunit/phpunit:^9.3 --dev --no-update
         - composer update --ignore-platform-req=php --no-progress --prefer-dist
     - name: PHP 7 Integration Tests

--- a/test_old/run-php-src.sh
+++ b/test_old/run-php-src.sh
@@ -1,9 +1,5 @@
-if [[ $1 == '7' ]]; then
-	VERSION='fa9bd812fcab6dfd6d9b506cb3cb04dfa75d239d'
-else
-	VERSION='05478e985eb50c473054b4f1bf174f48ead78784'
-fi
-wget -q https://github.com/php/php-src/archive/$VERSION.tar.gz
+VERSION=$1
+wget -q https://github.com/php/php-src/archive/php-$VERSION.tar.gz
 mkdir -p ./data/php-src
-tar -xzf ./$VERSION.tar.gz -C ./data/php-src --strip-components=1
-php -n test_old/run.php --verbose --no-progress PHP$1 ./data/php-src
+tar -xzf ./php-$VERSION.tar.gz -C ./data/php-src --strip-components=1
+php -n test_old/run.php --verbose --no-progress --php-version=$VERSION PHP ./data/php-src

--- a/test_old/run-php-src.sh
+++ b/test_old/run-php-src.sh
@@ -1,5 +1,9 @@
-VERSION="master"
+if [[ $1 == '7' ]]; then
+	VERSION='PHP-7.4'
+else
+	VERSION='master'
+fi
 wget -q https://github.com/php/php-src/archive/$VERSION.tar.gz
 mkdir -p ./data/php-src
 tar -xzf ./$VERSION.tar.gz -C ./data/php-src --strip-components=1
-php -n test_old/run.php --verbose --no-progress PHP7 ./data/php-src
+php -n test_old/run.php --verbose --no-progress PHP$1 ./data/php-src

--- a/test_old/run-php-src.sh
+++ b/test_old/run-php-src.sh
@@ -1,7 +1,7 @@
 if [[ $1 == '7' ]]; then
-	VERSION='PHP-7.4'
+	VERSION='fa9bd812fcab6dfd6d9b506cb3cb04dfa75d239d'
 else
-	VERSION='master'
+	VERSION='05478e985eb50c473054b4f1bf174f48ead78784'
 fi
 wget -q https://github.com/php/php-src/archive/$VERSION.tar.gz
 mkdir -p ./data/php-src


### PR DESCRIPTION
1. PHPUnit 8 doesn't work on PHP 8.0. PHPUnit 9.3(-dev) is required.
2. The "old test" runner was broken by 69c5d48afd1e631290de1aa9806eab0b38bb66a3. This PR fixes that*.

\* Note that the old tests are still failing due to https://github.com/nikic/PHP-Parser/issues/679, but the old tests fundamentally can't run on PHP 7 anymore because of the fact php-parser doesn't distinguish php 7 from 8 like it did with 5.