### PR TITLE
Show attributes available in node dumps with php-parse binary

### DIFF
--- a/bin/php-parse
+++ b/bin/php-parse
@@ -34,6 +34,7 @@ $parser = (new PhpParser\ParserFactory)->create(
     $lexer
 );
 $dumper = new PhpParser\NodeDumper([
+    'dumpAttributes' => $attributes['with-attributes'],
     'dumpComments' => true,
     'dumpPositions' => $attributes['with-positions'],
 ]);
@@ -41,6 +42,9 @@ $prettyPrinter = new PhpParser\PrettyPrinter\Standard;
 
 $traverser = new PhpParser\NodeTraverser();
 $traverser->addVisitor(new PhpParser\NodeVisitor\NameResolver);
+if ($attributes['with-attributes']) {
+    $traverser->addVisitor(new PhpParser\NodeVisitor\NodeConnectingVisitor());
+}
 
 foreach ($files as $file) {
     if (strpos($file, '<?php') === 0) {
@@ -122,6 +126,7 @@ Operations is a list of the following options (--dump by default):
     -N, --resolve-names     Resolve names using NodeVisitor\NameResolver
     -c, --with-column-info  Show column-numbers for errors (if available)
     -P, --with-positions    Show positions in node dumps
+    -a, --with-attributes   Show attributes available in node dumps
     -r, --with-recovery     Use parsing with error recovery
     -h, --help              Display this page
 
@@ -142,6 +147,7 @@ function parseArgs($args) {
     $attributes = [
         'with-column-info' => false,
         'with-positions' => false,
+        'with-attributes' => false,
         'with-recovery' => false,
     ];
 
@@ -180,6 +186,10 @@ function parseArgs($args) {
             case '--with-positions':
             case '-P':
                 $attributes['with-positions'] = true;
+                break;
+            case '--with-attributes':
+            case '-a':
+                $attributes['with-attributes'] = true;
                 break;
             case '--with-recovery':
             case '-r':

--- a/lib/PhpParser/NodeDumper.php
+++ b/lib/PhpParser/NodeDumper.php
@@ -10,6 +10,7 @@ use PhpParser\Node\Stmt\UseUse;
 
 class NodeDumper
 {
+    private $dumpAttributes;
     private $dumpComments;
     private $dumpPositions;
     private $code;
@@ -18,6 +19,7 @@ class NodeDumper
      * Constructs a NodeDumper.
      *
      * Supported options:
+     *  * bool dumpAttributes: Whether attributes should be dumped.
      *  * bool dumpComments: Whether comments should be dumped.
      *  * bool dumpPositions: Whether line/offset information should be dumped. To dump offset
      *                        information, the code needs to be passed to dump().
@@ -25,6 +27,7 @@ class NodeDumper
      * @param array $options Options (see description)
      */
     public function __construct(array $options = []) {
+        $this->dumpAttributes = !empty($options['dumpAttributes']);
         $this->dumpComments = !empty($options['dumpComments']);
         $this->dumpPositions = !empty($options['dumpPositions']);
     }
@@ -80,6 +83,10 @@ class NodeDumper
 
             if ($this->dumpComments && $comments = $node->getComments()) {
                 $r .= "\n    comments: " . str_replace("\n", "\n    ", $this->dumpRecursive($comments));
+            }
+
+            if ($this->dumpAttributes && $attrs = $node->getAttributes()) {
+                $r .= "\n    attributes: " . str_replace("\n", "\n    ", $this->dumpRecursive(array_keys($attrs)));
             }
         } elseif (is_array($node)) {
             $r = 'array(';

--- a/lib/PhpParser/NodeDumper.php
+++ b/lib/PhpParser/NodeDumper.php
@@ -86,7 +86,17 @@ class NodeDumper
             }
 
             if ($this->dumpAttributes && $attrs = $node->getAttributes()) {
-                $r .= "\n    attributes: " . str_replace("\n", "\n    ", $this->dumpRecursive(array_keys($attrs)));
+                $attributes = $node->getAttributes();
+
+                foreach ($attributes as $key => $attr) {
+                    if ($attr instanceof Node) {
+                        $attributes[$key] = ['type' => $attr->getType()];
+                    } elseif (!is_array($attr)) {
+                        $attributes[$key] = [gettype($attr) => $attr];
+                        continue;
+                    }
+                }
+                $r .= "\n    attributes: " . str_replace("\n", "\n    ", $this->dumpRecursive($attributes));
             }
         } elseif (is_array($node)) {
             $r = 'array(';


### PR DESCRIPTION
Hello Nikita and Sebastian (@sebastianbergmann )

Following relase of official version 4.7.0 that include now the new visitors `ParentConnectingVisitor` and `NodeConnectingVisitor`, I've modified the `bin/php-parse` command line tools to be able to show attributes on all node dumps.

Useful to detect what attributes are sets or not.

Second part (that is not part of my PR),  I've a question to Sebastian about **parent** attribute : is it the expected behaviour to set the parent as current node when there are no parent ? 

On my PR, I've added following a foreach loop code to see (the possible issue) in action : 

```php
            if ($this->dumpAttributes && $attrs = $node->getAttributes()) {
                $r .= "\n    attributes: " . str_replace("\n", "\n    ", $this->dumpRecursive(array_keys($attrs)));

                foreach (['parent', 'previous', 'next'] as $attr) {
                    if (isset($attrs[$attr]) && property_exists($attrs[$attr], 'name')) {
                        $r .= "\n    {$attr}: "
                            . str_replace(
                                "\n",
                                "\n    ",
                                $this->dumpRecursive([
                                    'type' => $attrs[$attr]->getType(),
                                    'name' => method_exists($attrs[$attr]->name, '__toString') ? (string) $attrs[$attr]->name : null
                                ])
                            );
                    }
                }
            }

```

Example with command : 
```bash
bin/php-parse -N -d -a lib/PhpParser/NodeDumper.php
```

That produces chunk of this ouptut  
```
    1: Stmt_Namespace(
        name: Name(
            parts: array(
                0: PhpParser
            )
            attributes: array(
                0: startLine
                1: startFilePos
                2: endLine
                3: endFilePos
                4: parent
                5: next
            )
            parent: array(
                type: Stmt_Namespace
                name: PhpParser
            )
        )
        stmts: array(
```

Your feedback are welcome !