### PR TITLE
Update Array_ annotations, items are nullable

### DIFF
--- a/lib/PhpParser/Node/Expr/Array_.php
+++ b/lib/PhpParser/Node/Expr/Array_.php
@@ -10,13 +10,13 @@ class Array_ extends Expr
     const KIND_LONG = 1;  // array() syntax
     const KIND_SHORT = 2; // [] syntax
 
-    /** @var ArrayItem[] Items */
+    /** @var (ArrayItem|null)[] Items */
     public $items;
 
     /**
      * Constructs an array node.
      *
-     * @param ArrayItem[] $items      Items of the array
+     * @param (ArrayItem|null)[] $items      Items of the array
      * @param array       $attributes Additional attributes
      */
     public function __construct(array $items = [], array $attributes = []) {


### PR DESCRIPTION
When used to destructure items are optional just as with `list()`. E.g. `[$a, , $b] = [1, 2, 3];`.