### PR TITLE
Failing test for format-preserving printer - empty line is removed

### DIFF
--- a/test/code/formatPreservation/removingExpr.test
+++ b/test/code/formatPreservation/removingExpr.test
@@ -1,0 +1,26 @@
+Removing statement with expression
+-----
+<?php
+function doBar(\DateTimeImmutable $date)
+{
+    'foo';
+    $date === null ? 'foo' : 'bar';
+    $date ? 'foo' : 'bar';
+    !$date ? 'foo' : 'bar';
+
+    $date ?: 'test';
+    $date ? $date : 'test';
+}
+-----
+array_splice($stmts[0]->stmts, 0, 1, []);
+-----
+<?php
+function doBar(\DateTimeImmutable $date)
+{
+    $date === null ? 'foo' : 'bar';
+    $date ? 'foo' : 'bar';
+    !$date ? 'foo' : 'bar';
+
+    $date ?: 'test';
+    $date ? $date : 'test';
+}


### PR DESCRIPTION
Hi, I'm not sure if it's possible to solve this but I'd expect the empty line between `!$date ? 'foo' : 'bar';` and `$date ?: 'test';` to be preserved. I'm only removing the first statement from the function body.

The attached test fails like this:

```
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
     $date === null ? 'foo' : 'bar';
     $date ? 'foo' : 'bar';
     !$date ? 'foo' : 'bar';
-
     $date ?: 'test';
     $date ? $date : 'test';
 }
```