### PR TITLE
FPPP failing test case with class nodes example

### DIFF
--- a/test/code/formatPreservation/listRemoval.test
+++ b/test/code/formatPreservation/listRemoval.test
@@ -174,3 +174,36 @@ try {
 } catch (\Throwable $e) {
 
 }
+-----
+<?php
+class Foo
+{
+    private $id;
+
+    public function getId()
+    {
+    }
+
+    public function getFoo()
+    {
+    }
+}
+-----
+$stmts[0]->stmts[2] = new Node\Stmt\ClassMethod('getBar');
+$stmts[0]->stmts[3] = new Node\Stmt\ClassMethod('getBaz');
+-----
+<?php
+class Foo
+{
+    private $id;
+
+    public function getId()
+    {
+    }
+    function getBar()
+    {
+    }
+    function getBaz()
+    {
+    }
+}


### PR DESCRIPTION
Hi!

I found a small regression after #699, so sha: bd722809f73f84a8025ba368ae2fd056f562a6b7

In this case, the line break is lost between the original `private $id` and `public function getId()`. To trigger this, you appear to need to replace a node (index 2, `getFoo()) *and* add another new node after that. This triggers the lost line break on the earlier nodes.

Thanks!