### PR TITLE
Improvement for early detection of conflicts with other libraries

### DIFF
--- a/lib/PhpParser/Lexer.php
+++ b/lib/PhpParser/Lexer.php
@@ -406,32 +406,44 @@ class Lexer
 
     private function defineCompatibilityTokens() {
         // PHP 7.4
-        if (!defined('T_BAD_CHARACTER')) {
+        if (\PHP_VERSION_ID < 70400) {
+            if(\defined('T_BAD_CHARACTER')) {
+                throw new \RuntimeException('Constant T_BAD_CHARACTER already defined');
+            }
             \define('T_BAD_CHARACTER', -1);
-        }
-        if (!defined('T_FN')) {
+            if(\defined('T_FN')) {
+                throw new \RuntimeException('Constant T_FN already defined');
+            }
             \define('T_FN', -2);
-        }
-        if (!defined('T_COALESCE_EQUAL')) {
+            if(\defined('T_COALESCE_EQUAL')) {
+                throw new \RuntimeException('Constant T_COALESCE_EQUAL already defined');
+            }        
             \define('T_COALESCE_EQUAL', -3);
-        }
+        }        
 
         // PHP 8.0
-        if (!defined('T_NAME_QUALIFIED')) {
+        if (\PHP_VERSION_ID < 80000) {
+            if(\defined('T_NAME_QUALIFIED')) {
+                throw new \RuntimeException('Constant T_NAME_QUALIFIED already defined');
+            }
             \define('T_NAME_QUALIFIED', -4);
-        }
-        if (!defined('T_NAME_FULLY_QUALIFIED')) {
+            if(\defined('T_NAME_FULLY_QUALIFIED')) {
+                throw new \RuntimeException('Constant T_NAME_FULLY_QUALIFIED already defined');
+            }
             \define('T_NAME_FULLY_QUALIFIED', -5);
-        }
-        if (!defined('T_NAME_RELATIVE')) {
+            if(\defined('T_NAME_RELATIVE')) {
+                throw new \RuntimeException('Constant T_NAME_RELATIVE already defined');
+            }
             \define('T_NAME_RELATIVE', -6);
-        }
-        if (!defined('T_MATCH')) {
+            if(\defined('T_MATCH')) {
+                throw new \RuntimeException('Constant T_MATCH already defined');
+            }
             \define('T_MATCH', -7);
-        }
-        if (!defined('T_NULLSAFE_OBJECT_OPERATOR')) {
+            if(\defined('T_NULLSAFE_OBJECT_OPERATOR')) {
+                throw new \RuntimeException('Constant T_NULLSAFE_OBJECT_OPERATOR already defined');
+            }        
             \define('T_NULLSAFE_OBJECT_OPERATOR', -8);
-        }
+        }        
     }
 
     /**


### PR DESCRIPTION
Today I ran into a conflict with `nikic/php-parser: 4.9.1` and `zircote/php-swagger: 3.0.5` (https://github.com/zircote/swagger-php/issues/839). It seems that in both librarys efforts have been made to be compatible with PHP 8.0 by defining polyfills for the constants of the new tokens `T_NAME_X`. It is conceivable that developers of other open source libraries maybe will do the same thing.

I've spent many hours of debugging to find out that there is a conflict with `zircote/php-swagger`.

The error `Parse error: Syntax error, unexpected T_NAME_FULLY_QUALIFIED, expecting T_STRING or T_NAME_QUALIFIED or '{' on line 4` can be reproduced by this example and at least both already mentioned dependencies in `composer.json`:

```php
$parser = (new \PhpParser\ParserFactory)->create(\PhpParser\ParserFactory::ONLY_PHP7);

$fileContent = <<<EOF
<?php
declare(strict_types=1);

namespace Foo\Bar;

class Test
{

}
EOF;

try {
    $ast = $parser->parse($fileContent);
} catch (\PhpParser\Error $error) {
    echo 'Parse error: ' . $error->getMessage();
}
```

In my opinion, the parser should not proceed (by throwing a `\RuntimeException`) if one of the constants is already defined because this could lead to unexpected behaviour like in the given example.

