### PR TITLE
PrettyPrinter\\Standard: fixes nested ternaries output;

### DIFF
--- a/lib/PhpParser/PrettyPrinter/Standard.php
+++ b/lib/PhpParser/PrettyPrinter/Standard.php
@@ -659,6 +659,12 @@ class Standard extends PrettyPrinterAbstract
     }
 
     protected function pExpr_Ternary(Expr\Ternary $node) {
+        if ($node->cond instanceof Expr\Ternary) {
+            return '(' . $this->pInfixOp(Expr\Ternary::class,
+                $node->cond, ') ?' . (null !== $node->if ? ' ' . $this->p($node->if) . ' ' : '') . ': ', $node->else
+            );
+        }
+
         // a bit of cheating: we treat the ternary as a binary op where the ?...: part is the operator.
         // this is okay because the part between ? and : never needs parentheses.
         return $this->pInfixOp(Expr\Ternary::class,

--- a/test/code/prettyPrinter/expr/parentheses.test
+++ b/test/code/prettyPrinter/expr/parentheses.test
@@ -59,7 +59,7 @@ $a = $b = $c = $d = $f && true;
 ($a = $b = $c = $d = $f) && true;
 $a = $b = $c = $d = $f and true;
 $a = $b = $c = $d = ($f and true);
-$a ? $b : $c ? $d : $e ? $f : $g;
+(($a ? $b : $c) ? $d : $e) ? $f : $g;
 $a ? $b : ($c ? $d : ($e ? $f : $g));
 $a ? $b ? $c : $d : $f;
 $a ?? $b ?? $c;


### PR DESCRIPTION
Fixes #718 

That fixes it, but I don't know if it's the best way.

I also had to modify one of the tests, because it is "positively affected" by this commit. The previous expected output would generate the error mentioned in #718.