### PR TITLE
Introduce node scalar escaped to avoid wrong escaping - Close #725

### DIFF
--- a/lib/PhpParser/Node/Scalar/Escaped_.php
+++ b/lib/PhpParser/Node/Scalar/Escaped_.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types=1);
+
+namespace PhpParser\Node\Scalar;
+
+use PhpParser\Node\Scalar;
+
+class Escaped_ extends Scalar
+{
+    /** @var string String value */
+    public $value;
+
+    /**
+     * Constructs a string scalar node.
+     *
+     * @param string $value      Value of the string
+     * @param array  $attributes Additional attributes
+     */
+    public function __construct(string $value, array $attributes = []) {
+        $this->attributes = $attributes;
+        $this->value = $value;
+    }
+
+    public function getSubNodeNames() : array {
+        return ['value'];
+    }
+
+    public function getType() : string {
+        return 'Scalar_Escaped';
+    }
+}

--- a/lib/PhpParser/PrettyPrinter/Standard.php
+++ b/lib/PhpParser/PrettyPrinter/Standard.php
@@ -112,6 +112,10 @@ class Standard extends PrettyPrinterAbstract
 
     // Scalars
 
+    protected function pScalar_Escaped(Scalar\Escaped_ $node) {
+        return $node->value;
+    }
+
     protected function pScalar_String(Scalar\String_ $node) {
         $kind = $node->getAttribute('kind', Scalar\String_::KIND_SINGLE_QUOTED);
         switch ($kind) {

--- a/test/PhpParser/PrettyPrinterTest.php
+++ b/test/PhpParser/PrettyPrinterTest.php
@@ -210,6 +210,13 @@ class PrettyPrinterTest extends CodeTestAbstract
         $prettyPrinter->prettyPrintExpr($expr);
     }
 
+    public function testPrettyPrintEscapedString() {
+        $expr = new Node\Scalar\Escaped_("Y-m-d\TH:i:sP"); // DATE_ATOM
+        $prettyPrinter = new PrettyPrinter\Standard;
+
+        $this->assertEquals('Y-m-d\TH:i:sP',  $prettyPrinter->prettyPrintExpr($expr));
+    }
+
     /**
      * @dataProvider provideTestFormatPreservingPrint
      * @covers \PhpParser\PrettyPrinter\Standard<extended>


### PR DESCRIPTION
See #725 for more details. 

It's needed for code generation where the value should not be escaped.