### PR TITLE
Fixed type vs string

### DIFF
--- a/lib/PhpParser/Internal/TokenStream.php
+++ b/lib/PhpParser/Internal/TokenStream.php
@@ -46,7 +46,8 @@ class TokenStream
      * @return bool
      */
     public function haveBraces(int $startPos, int $endPos) : bool {
-        return $this->haveTokenImmediatelyBefore($startPos, '{')
+        return ($this->haveTokenImmediatelyBefore($startPos, '{')
+                || $this->haveTokenImmediatelyBefore($startPos, T_CURLY_OPEN))
             && $this->haveTokenImmediatelyAfter($endPos, '}');
     }
 
@@ -201,6 +202,7 @@ class TokenStream
 
     public function haveBracesInRange(int $startPos, int $endPos) {
         return $this->haveTokenInRange($startPos, $endPos, '{')
+            || $this->haveTokenInRange($startPos, $endPos, T_CURLY_OPEN)
             || $this->haveTokenInRange($startPos, $endPos, '}');
     }
 

--- a/test/code/formatPreservation/rewriteVariableInterpolationString.test
+++ b/test/code/formatPreservation/rewriteVariableInterpolationString.test
@@ -1,0 +1,9 @@
+Rewrite string with variable interpolation
+-----
+<?php
+"{$e}";
+-----
+$stmts[0]->expr->parts[0]->setAttribute('origNode', null);
+-----
+<?php
+"{$e}";


### PR DESCRIPTION
Php parses `{` as an array `[0 => 386,1 => '{',2 => 12,]` so this check doesn't work properly. My edit fixes this.