### PR TITLE
Test trait with conditionals beforehand

### DIFF
--- a/test/code/parser/stmt/traitOptionalAttributes.test
+++ b/test/code/parser/stmt/traitOptionalAttributes.test
@@ -1,0 +1,113 @@
+Trait optional attributes
+-----
+<?php
+
+if (!trait_exists(FoobarBaz::class, FALSE)) {
+    class_alias("Foo\Bar\Baz", FoobarBaz::class);
+}
+
+trait CompatibilityTrait {
+    use FoobarBaz;
+}
+-----
+array(
+    0: Stmt_If(
+        cond: Expr_BooleanNot(
+            expr: Expr_FuncCall(
+                name: Name(
+                    parts: array(
+                        0: trait_exists
+                    )
+                )
+                args: array(
+                    0: Arg(
+                        name: null
+                        value: Expr_ClassConstFetch(
+                            class: Name(
+                                parts: array(
+                                    0: FoobarBaz
+                                )
+                            )
+                            name: Identifier(
+                                name: class
+                            )
+                        )
+                        byRef: false
+                        unpack: false
+                    )
+                    1: Arg(
+                        name: null
+                        value: Expr_ConstFetch(
+                            name: Name(
+                                parts: array(
+                                    0: FALSE
+                                )
+                            )
+                        )
+                        byRef: false
+                        unpack: false
+                    )
+                )
+            )
+        )
+        stmts: array(
+            0: Stmt_Expression(
+                expr: Expr_FuncCall(
+                    name: Name(
+                        parts: array(
+                            0: class_alias
+                        )
+                    )
+                    args: array(
+                        0: Arg(
+                            name: null
+                            value: Scalar_String(
+                                value: Foo\Bar\Baz
+                            )
+                            byRef: false
+                            unpack: false
+                        )
+                        1: Arg(
+                            name: null
+                            value: Expr_ClassConstFetch(
+                                class: Name(
+                                    parts: array(
+                                        0: FoobarBaz
+                                    )
+                                )
+                                name: Identifier(
+                                    name: class
+                                )
+                            )
+                            byRef: false
+                            unpack: false
+                        )
+                    )
+                )
+            )
+        )
+        elseifs: array(
+        )
+        else: null
+    )
+    1: Stmt_Trait(
+        attrGroups: array(
+        )
+        name: Identifier(
+            name: CompatibilityTrait
+        )
+        stmts: array(
+            0: Stmt_TraitUse(
+                traits: array(
+                    0: Name(
+                        parts: array(
+                            0: FoobarBaz
+                        )
+                    )
+                )
+                adaptations: array(
+                )
+            )
+        )
+    )
+)


### PR DESCRIPTION
This an attempt at a test for https://github.com/nikic/PHP-Parser/issues/738. The assertion fails on:

```
\assert($itemStartPos >= 0 && $itemEndPos >= 0 && $itemStartPos >= $pos);
```

So locally I quick added this:

```
                if ($itemStartPos >= 0 && $itemEndPos >= 0 && $itemStartPos < $pos) {
                  var_dump($origArrItem);
                }
```

Which output:

```
class PhpParser\Node\Stmt\Trait_#89066 (4) {
  public $name =>
  class PhpParser\Node\Identifier#89069 (2) {
    public $name =>
    string(18) "CompatibilityTrait"
    protected $attributes =>
    array(4) {
      'startLine' =>
      int(7)
      'startTokenPos' =>
      int(34)
      'endLine' =>
      int(7)
      'endTokenPos' =>
      int(34)
    }
  }
  public $stmts =>
  array(1) {
    [0] =>
    class PhpParser\Node\Stmt\TraitUse#89067 (3) {
      public $traits =>
      array(1) {
        ...
      }
      public $adaptations =>
      array(0) {
        ...
      }
      protected $attributes =>
      array(4) {
        ...
      }
    }
  }
  public $attrGroups =>
  array(0) {
  }
  protected $attributes =>
  array(4) {
    'startLine' =>
    int(3)
    'startTokenPos' =>
    int(2)
    'endLine' =>
    int(9)
    'endTokenPos' =>
    int(43)
  }
}
```

The `PhpParser\Node\Identifier` has the correct start line of `7`, but the `Stmt\Trait_` has a start line of `3`.

For #739 