### PR TITLE
Add .github directory to .gitattributes export-ignore

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,9 +1,9 @@
-/doc export-ignore
-/test export-ignore
-/test_old export-ignore
-.gitattributes export-ignore
-.gitignore export-ignore
-.travis.yml export-ignore
-CHANGELOG.md export-ignore
+/.github         export-ignore
+/doc             export-ignore
+/test            export-ignore
+/test_old        export-ignore
+.gitattributes   export-ignore
+.gitignore       export-ignore
+CHANGELOG.md     export-ignore
 phpunit.xml.dist export-ignore
-UPGRADE-*.md export-ignore
+UPGRADE-*.md     export-ignore


### PR DESCRIPTION
Adds `.github` directory to `.gitattributes` file with an `export-ignore` rule.
This also aligns all `export-ignore` rules for more readability.

Thank you.