### PR TITLE
make Namespace_ builder return Namespace_

### DIFF
--- a/lib/PhpParser/Builder/Namespace_.php
+++ b/lib/PhpParser/Builder/Namespace_.php
@@ -37,7 +37,7 @@ class Namespace_ extends Declaration
     /**
      * Returns the built node.
      *
-     * @return Node The built node
+     * @return Stmt\Namespace_ The built node
      */
     public function getNode() : Node {
         return new Stmt\Namespace_($this->name, $this->stmts, $this->attributes);


### PR DESCRIPTION
Hi, just a little detail. This should fix invalid return type of docs
Other builders already return specific type.

## Before :no_entry_sign: 

![image](https://user-images.githubusercontent.com/924196/103319112-f2f59b00-4a30-11eb-8206-25459e72a138.png)


## After :heavy_check_mark: 

![image](https://user-images.githubusercontent.com/924196/103319156-14ef1d80-4a31-11eb-846e-6b485b5497bd.png)
