### PR TITLE
Fix bug in pretty printer

### DIFF
--- a/lib/PhpParser/PrettyPrinter/Standard.php
+++ b/lib/PhpParser/PrettyPrinter/Standard.php
@@ -638,7 +638,7 @@ class Standard extends PrettyPrinterAbstract
             . '(' . $this->pCommaSeparated($node->params) . ')'
             . (null !== $node->returnType ? ': ' . $this->p($node->returnType) : '')
             . ' => '
-            . $this->p($node->expr);
+            . $this->pDereferenceLhs($node->expr);
     }
 
     protected function pExpr_ClosureUse(Expr\ClosureUse $node) {

--- a/lib/PhpParser/PrettyPrinter/Standard.php
+++ b/lib/PhpParser/PrettyPrinter/Standard.php
@@ -1032,8 +1032,11 @@ class Standard extends PrettyPrinterAbstract
     }
 
     protected function pNewVariable(Node $node) {
-        // TODO: This is not fully accurate.
-        return $this->pDereferenceLhs($node);
+        if (!$node instanceof Scalar\String_) {
+            return $this->pDereferenceLhs($node);
+        } else {
+            return '(' . $this->p($node) . ')';
+        }
     }
 
     /**

--- a/test/code/formatPreservation/attributes.test
+++ b/test/code/formatPreservation/attributes.test
@@ -151,7 +151,7 @@ new #[A] class
 };
 #[A] function () {
 };
-#[A] fn() => 42;
+#[A] fn() => (42);
 -----
 <?php
 

--- a/test/code/prettyPrinter/stmt/attributes.test
+++ b/test/code/prettyPrinter/stmt/attributes.test
@@ -55,7 +55,7 @@ trait T
 }
 $x = #[A10] function () {
 };
-$y = #[A11] fn() => 0;
+$y = #[A11] fn() => (0);
 new #[A13] class
 {
 };


### PR DESCRIPTION
Starting from PHP 8, a number of additional expressions and non-expressions can appear on the rhs of an instanceof expression, including a string (appropriately wrapped in parenthesis).