### PR TITLE
chore: use the word Xdebug instead of XDebug

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ Component documentation:
  * [JSON representation](doc/component/JSON_representation.markdown)
    * JSON encoding and decoding of ASTs
  * [Performance](doc/component/Performance.markdown)
-   * Disabling XDebug
+   * Disabling Xdebug
    * Reusing objects
    * Garbage collection impact
  * [Frequently asked questions](doc/component/FAQ.markdown)

--- a/bin/php-parse
+++ b/bin/php-parse
@@ -10,7 +10,7 @@ foreach ([__DIR__ . '/../../../autoload.php', __DIR__ . '/../vendor/autoload.php
 
 ini_set('xdebug.max_nesting_level', 3000);
 
-// Disable XDebug var_dump() output truncation
+// Disable Xdebug var_dump() output truncation
 ini_set('xdebug.var_display_max_children', -1);
 ini_set('xdebug.var_display_max_data', -1);
 ini_set('xdebug.var_display_max_depth', -1);

--- a/doc/2_Usage_of_basic_components.markdown
+++ b/doc/2_Usage_of_basic_components.markdown
@@ -19,7 +19,7 @@ ini_set('xdebug.max_nesting_level', 3000);
 ```
 
 This ensures that there will be no errors when traversing highly nested node trees. However, it is
-preferable to disable XDebug completely, as it can easily make this library more than five times
+preferable to disable Xdebug completely, as it can easily make this library more than five times
 slower.
 
 Parsing

--- a/doc/README.md
+++ b/doc/README.md
@@ -39,7 +39,7 @@ Component documentation
   * [JSON representation](component/JSON_representation.markdown)
     * JSON encoding and decoding of ASTs
   * [Performance](component/Performance.markdown)
-    * Disabling XDebug
+    * Disabling Xdebug
     * Reusing objects
     * Garbage collection impact
   * [Frequently asked questions](component/FAQ.markdown)

--- a/doc/component/Performance.markdown
+++ b/doc/component/Performance.markdown
@@ -8,20 +8,20 @@ described in the following.
 Xdebug
 ------
 
-Running PHP with XDebug adds a lot of overhead, especially for code that performs many method calls.
-Just by loading XDebug (without enabling profiling or other more intrusive XDebug features), you
+Running PHP with Xdebug adds a lot of overhead, especially for code that performs many method calls.
+Just by loading Xdebug (without enabling profiling or other more intrusive Xdebug features), you
 can expect that code using PHP-Parser will be approximately *five times slower*.
 
-As such, you should make sure that XDebug is not loaded when using this library. Note that setting
-the `xdebug.default_enable=0` ini option does *not* disable XDebug. The *only* way to disable
-XDebug is to not load the extension in the first place.
+As such, you should make sure that Xdebug is not loaded when using this library. Note that setting
+the `xdebug.default_enable=0` ini option does *not* disable Xdebug. The *only* way to disable
+Xdebug is to not load the extension in the first place.
 
-If you are building a command-line utility for use by developers (who often have XDebug enabled),
-you may want to consider automatically restarting PHP with XDebug unloaded. The
+If you are building a command-line utility for use by developers (who often have Xdebug enabled),
+you may want to consider automatically restarting PHP with Xdebug unloaded. The
 [composer/xdebug-handler](https://github.com/composer/xdebug-handler) package can be used to do
 this.
 
-If you do run with XDebug, you may need to increase the `xdebug.max_nesting_level` option to a
+If you do run with Xdebug, you may need to increase the `xdebug.max_nesting_level` option to a
 higher level, such as 3000. While the parser itself is recursion free, most other code working on
 the AST uses recursion and will generate an error if the value of this option is too low.
 


### PR DESCRIPTION
This PR makes @derickr happy by using the word Xdebug instead of XDebug :)