### PR TITLE
Add addAttribute() method to Builders with normalizer

### DIFF
--- a/lib/PhpParser/Builder/ClassConst.php
+++ b/lib/PhpParser/Builder/ClassConst.php
@@ -6,6 +6,7 @@ namespace PhpParser\Builder;
 
 use PhpParser;
 use PhpParser\BuilderHelpers;
+use PhpParser\Node;
 use PhpParser\Node\Const_;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Stmt;
@@ -15,6 +16,9 @@ class ClassConst implements PhpParser\Builder
     protected $flags = 0;
     protected $attributes = [];
     protected $constants = [];
+
+    /** @var Node\AttributeGroup[] */
+    protected $attributeGroups = [];
 
     /**
      * Creates a class constant builder
@@ -89,6 +93,19 @@ class ClassConst implements PhpParser\Builder
     }
 
     /**
+     * Adds an attribute group to the constant.
+     *
+     * @param Node\AttributeGroup $attributeGroup
+     *
+     * @return $this The builder instance (for fluid interface)
+     */
+    public function addAttributeGroup(Node\AttributeGroup $attributeGroup) {
+        $this->attributeGroups[] = $attributeGroup;
+
+        return $this;
+    }
+
+    /**
      * Returns the built class node.
      *
      * @return Stmt\ClassConst The built constant node
@@ -97,7 +114,8 @@ class ClassConst implements PhpParser\Builder
         return new Stmt\ClassConst(
             $this->constants,
             $this->flags,
-            $this->attributes
+            $this->attributes,
+            $this->attributeGroups
         );
     }
 }

--- a/lib/PhpParser/Builder/ClassConst.php
+++ b/lib/PhpParser/Builder/ClassConst.php
@@ -93,7 +93,7 @@ class ClassConst implements PhpParser\Builder
     }
 
     /**
-     * Adds an attribute group to the constant.
+     * Adds an attribute group.
      *
      * @param Node\Attribute|Node\AttributeGroup $attribute
      *

--- a/lib/PhpParser/Builder/ClassConst.php
+++ b/lib/PhpParser/Builder/ClassConst.php
@@ -95,12 +95,12 @@ class ClassConst implements PhpParser\Builder
     /**
      * Adds an attribute group to the constant.
      *
-     * @param Node\AttributeGroup $attributeGroup
+     * @param Node\Attribute|Node\AttributeGroup $attribute
      *
      * @return $this The builder instance (for fluid interface)
      */
-    public function addAttributeGroup(Node\AttributeGroup $attributeGroup) {
-        $this->attributeGroups[] = $attributeGroup;
+    public function addAttribute($attribute) {
+        $this->attributeGroups[] = BuilderHelpers::normalizeAttribute($attribute);
 
         return $this;
     }

--- a/lib/PhpParser/Builder/Class_.php
+++ b/lib/PhpParser/Builder/Class_.php
@@ -4,6 +4,7 @@ namespace PhpParser\Builder;
 
 use PhpParser;
 use PhpParser\BuilderHelpers;
+use PhpParser\Node;
 use PhpParser\Node\Name;
 use PhpParser\Node\Stmt;
 
@@ -19,6 +20,9 @@ class Class_ extends Declaration
     protected $constants = [];
     protected $properties = [];
     protected $methods = [];
+
+    /** @var Node\AttributeGroup[] */
+    protected $attributeGroups = [];
 
     /**
      * Creates a class builder.
@@ -107,6 +111,19 @@ class Class_ extends Declaration
     }
 
     /**
+     * Adds an attribute group to the constant.
+     *
+     * @param Node\AttributeGroup $attributeGroup
+     *
+     * @return $this The builder instance (for fluid interface)
+     */
+    public function addAttributeGroup(Node\AttributeGroup $attributeGroup) {
+        $this->attributeGroups[] = $attributeGroup;
+
+        return $this;
+    }
+
+    /**
      * Returns the built class node.
      *
      * @return Stmt\Class_ The built class node
@@ -117,6 +134,7 @@ class Class_ extends Declaration
             'extends' => $this->extends,
             'implements' => $this->implements,
             'stmts' => array_merge($this->uses, $this->constants, $this->properties, $this->methods),
+            'attrGroups' => $this->attributeGroups,
         ], $this->attributes);
     }
 }

--- a/lib/PhpParser/Builder/Class_.php
+++ b/lib/PhpParser/Builder/Class_.php
@@ -113,12 +113,12 @@ class Class_ extends Declaration
     /**
      * Adds an attribute group to the constant.
      *
-     * @param Node\AttributeGroup $attributeGroup
+     * @param Node\Attribute|Node\AttributeGroup $attribute
      *
      * @return $this The builder instance (for fluid interface)
      */
-    public function addAttributeGroup(Node\AttributeGroup $attributeGroup) {
-        $this->attributeGroups[] = $attributeGroup;
+    public function addAttribute($attribute) {
+        $this->attributeGroups[] = BuilderHelpers::normalizeAttribute($attribute);
 
         return $this;
     }

--- a/lib/PhpParser/Builder/Class_.php
+++ b/lib/PhpParser/Builder/Class_.php
@@ -111,7 +111,7 @@ class Class_ extends Declaration
     }
 
     /**
-     * Adds an attribute group to the constant.
+     * Adds an attribute group.
      *
      * @param Node\Attribute|Node\AttributeGroup $attribute
      *

--- a/lib/PhpParser/Builder/Function_.php
+++ b/lib/PhpParser/Builder/Function_.php
@@ -40,12 +40,12 @@ class Function_ extends FunctionLike
     /**
      * Adds an attribute group to the constant.
      *
-     * @param Node\AttributeGroup $attributeGroup
+     * @param Node\Attribute|Node\AttributeGroup $attribute
      *
      * @return $this The builder instance (for fluid interface)
      */
-    public function addAttributeGroup(Node\AttributeGroup $attributeGroup) {
-        $this->attributeGroups[] = $attributeGroup;
+    public function addAttribute($attribute) {
+        $this->attributeGroups[] = BuilderHelpers::normalizeAttribute($attribute);
 
         return $this;
     }

--- a/lib/PhpParser/Builder/Function_.php
+++ b/lib/PhpParser/Builder/Function_.php
@@ -38,7 +38,7 @@ class Function_ extends FunctionLike
     }
 
     /**
-     * Adds an attribute group to the constant.
+     * Adds an attribute group.
      *
      * @param Node\Attribute|Node\AttributeGroup $attribute
      *

--- a/lib/PhpParser/Builder/Function_.php
+++ b/lib/PhpParser/Builder/Function_.php
@@ -12,6 +12,9 @@ class Function_ extends FunctionLike
     protected $name;
     protected $stmts = [];
 
+    /** @var Node\AttributeGroup[] */
+    protected $attributeGroups = [];
+
     /**
      * Creates a function builder.
      *
@@ -35,6 +38,19 @@ class Function_ extends FunctionLike
     }
 
     /**
+     * Adds an attribute group to the constant.
+     *
+     * @param Node\AttributeGroup $attributeGroup
+     *
+     * @return $this The builder instance (for fluid interface)
+     */
+    public function addAttributeGroup(Node\AttributeGroup $attributeGroup) {
+        $this->attributeGroups[] = $attributeGroup;
+
+        return $this;
+    }
+
+    /**
      * Returns the built function node.
      *
      * @return Stmt\Function_ The built function node
@@ -45,6 +61,7 @@ class Function_ extends FunctionLike
             'params'     => $this->params,
             'returnType' => $this->returnType,
             'stmts'      => $this->stmts,
+            'attrGroups' => $this->attributeGroups,
         ], $this->attributes);
     }
 }

--- a/lib/PhpParser/Builder/Interface_.php
+++ b/lib/PhpParser/Builder/Interface_.php
@@ -4,6 +4,7 @@ namespace PhpParser\Builder;
 
 use PhpParser;
 use PhpParser\BuilderHelpers;
+use PhpParser\Node;
 use PhpParser\Node\Name;
 use PhpParser\Node\Stmt;
 
@@ -13,6 +14,9 @@ class Interface_ extends Declaration
     protected $extends = [];
     protected $constants = [];
     protected $methods = [];
+
+    /** @var Node\AttributeGroup[] */
+    protected $attributeGroups = [];
 
     /**
      * Creates an interface builder.
@@ -62,6 +66,19 @@ class Interface_ extends Declaration
     }
 
     /**
+     * Adds an attribute group to the constant.
+     *
+     * @param Node\AttributeGroup $attributeGroup
+     *
+     * @return $this The builder instance (for fluid interface)
+     */
+    public function addAttributeGroup(Node\AttributeGroup $attributeGroup) {
+        $this->attributeGroups[] = $attributeGroup;
+
+        return $this;
+    }
+
+    /**
      * Returns the built interface node.
      *
      * @return Stmt\Interface_ The built interface node
@@ -70,6 +87,7 @@ class Interface_ extends Declaration
         return new Stmt\Interface_($this->name, [
             'extends' => $this->extends,
             'stmts' => array_merge($this->constants, $this->methods),
+            'attrGroups' => $this->attributeGroups,
         ], $this->attributes);
     }
 }

--- a/lib/PhpParser/Builder/Interface_.php
+++ b/lib/PhpParser/Builder/Interface_.php
@@ -66,7 +66,7 @@ class Interface_ extends Declaration
     }
 
     /**
-     * Adds an attribute group to the constant.
+     * Adds an attribute group.
      *
      * @param Node\Attribute|Node\AttributeGroup $attribute
      *

--- a/lib/PhpParser/Builder/Interface_.php
+++ b/lib/PhpParser/Builder/Interface_.php
@@ -68,12 +68,12 @@ class Interface_ extends Declaration
     /**
      * Adds an attribute group to the constant.
      *
-     * @param Node\AttributeGroup $attributeGroup
+     * @param Node\Attribute|Node\AttributeGroup $attribute
      *
      * @return $this The builder instance (for fluid interface)
      */
-    public function addAttributeGroup(Node\AttributeGroup $attributeGroup) {
-        $this->attributeGroups[] = $attributeGroup;
+    public function addAttribute($attribute) {
+        $this->attributeGroups[] = BuilderHelpers::normalizeAttribute($attribute);
 
         return $this;
     }

--- a/lib/PhpParser/Builder/Method.php
+++ b/lib/PhpParser/Builder/Method.php
@@ -118,12 +118,12 @@ class Method extends FunctionLike
     /**
      * Adds an attribute group to the constant.
      *
-     * @param Node\AttributeGroup $attributeGroup
+     * @param Node\Attribute|Node\AttributeGroup $attribute
      *
      * @return $this The builder instance (for fluid interface)
      */
-    public function addAttributeGroup(Node\AttributeGroup $attributeGroup) {
-        $this->attributeGroups[] = $attributeGroup;
+    public function addAttribute($attribute) {
+        $this->attributeGroups[] = BuilderHelpers::normalizeAttribute($attribute);
 
         return $this;
     }

--- a/lib/PhpParser/Builder/Method.php
+++ b/lib/PhpParser/Builder/Method.php
@@ -15,6 +15,9 @@ class Method extends FunctionLike
     /** @var array|null */
     protected $stmts = [];
 
+    /** @var Node\AttributeGroup[] */
+    protected $attributeGroups = [];
+
     /**
      * Creates a method builder.
      *
@@ -113,6 +116,19 @@ class Method extends FunctionLike
     }
 
     /**
+     * Adds an attribute group to the constant.
+     *
+     * @param Node\AttributeGroup $attributeGroup
+     *
+     * @return $this The builder instance (for fluid interface)
+     */
+    public function addAttributeGroup(Node\AttributeGroup $attributeGroup) {
+        $this->attributeGroups[] = $attributeGroup;
+
+        return $this;
+    }
+
+    /**
      * Returns the built method node.
      *
      * @return Stmt\ClassMethod The built method node
@@ -124,6 +140,7 @@ class Method extends FunctionLike
             'params'     => $this->params,
             'returnType' => $this->returnType,
             'stmts'      => $this->stmts,
+            'attrGroups' => $this->attributeGroups,
         ], $this->attributes);
     }
 }

--- a/lib/PhpParser/Builder/Method.php
+++ b/lib/PhpParser/Builder/Method.php
@@ -116,7 +116,7 @@ class Method extends FunctionLike
     }
 
     /**
-     * Adds an attribute group to the constant.
+     * Adds an attribute group.
      *
      * @param Node\Attribute|Node\AttributeGroup $attribute
      *

--- a/lib/PhpParser/Builder/Param.php
+++ b/lib/PhpParser/Builder/Param.php
@@ -19,6 +19,9 @@ class Param implements PhpParser\Builder
 
     protected $variadic = false;
 
+    /** @var Node\AttributeGroup[] */
+    protected $attributeGroups = [];
+
     /**
      * Creates a parameter builder.
      *
@@ -93,6 +96,19 @@ class Param implements PhpParser\Builder
     }
 
     /**
+     * Adds an attribute group to the constant.
+     *
+     * @param Node\AttributeGroup $attributeGroup
+     *
+     * @return $this The builder instance (for fluid interface)
+     */
+    public function addAttributeGroup(Node\AttributeGroup $attributeGroup) {
+        $this->attributeGroups[] = $attributeGroup;
+
+        return $this;
+    }
+
+    /**
      * Returns the built parameter node.
      *
      * @return Node\Param The built parameter node
@@ -100,7 +116,7 @@ class Param implements PhpParser\Builder
     public function getNode() : Node {
         return new Node\Param(
             new Node\Expr\Variable($this->name),
-            $this->default, $this->type, $this->byRef, $this->variadic
+            $this->default, $this->type, $this->byRef, $this->variadic, [], 0, $this->attributeGroups
         );
     }
 }

--- a/lib/PhpParser/Builder/Param.php
+++ b/lib/PhpParser/Builder/Param.php
@@ -98,12 +98,12 @@ class Param implements PhpParser\Builder
     /**
      * Adds an attribute group to the constant.
      *
-     * @param Node\AttributeGroup $attributeGroup
+     * @param Node\Attribute|Node\AttributeGroup $attribute
      *
      * @return $this The builder instance (for fluid interface)
      */
-    public function addAttributeGroup(Node\AttributeGroup $attributeGroup) {
-        $this->attributeGroups[] = $attributeGroup;
+    public function addAttribute($attribute) {
+        $this->attributeGroups[] = BuilderHelpers::normalizeAttribute($attribute);
 
         return $this;
     }

--- a/lib/PhpParser/Builder/Param.php
+++ b/lib/PhpParser/Builder/Param.php
@@ -96,7 +96,7 @@ class Param implements PhpParser\Builder
     }
 
     /**
-     * Adds an attribute group to the constant.
+     * Adds an attribute group.
      *
      * @param Node\Attribute|Node\AttributeGroup $attribute
      *

--- a/lib/PhpParser/Builder/Property.php
+++ b/lib/PhpParser/Builder/Property.php
@@ -121,12 +121,12 @@ class Property implements PhpParser\Builder
     /**
      * Adds an attribute group to the constant.
      *
-     * @param Node\AttributeGroup $attributeGroup
+     * @param Node\Attribute|Node\AttributeGroup $attribute
      *
      * @return $this The builder instance (for fluid interface)
      */
-    public function addAttributeGroup(Node\AttributeGroup $attributeGroup) {
-        $this->attributeGroups[] = $attributeGroup;
+    public function addAttribute($attribute) {
+        $this->attributeGroups[] = BuilderHelpers::normalizeAttribute($attribute);
 
         return $this;
     }

--- a/lib/PhpParser/Builder/Property.php
+++ b/lib/PhpParser/Builder/Property.php
@@ -4,6 +4,7 @@ namespace PhpParser\Builder;
 
 use PhpParser;
 use PhpParser\BuilderHelpers;
+use PhpParser\Node;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
 use PhpParser\Node\NullableType;
@@ -19,6 +20,9 @@ class Property implements PhpParser\Builder
 
     /** @var null|Identifier|Name|NullableType */
     protected $type;
+
+    /** @var Node\AttributeGroup[] */
+    protected $attributeGroups = [];
 
     /**
      * Creates a property builder.
@@ -115,6 +119,19 @@ class Property implements PhpParser\Builder
     }
 
     /**
+     * Adds an attribute group to the constant.
+     *
+     * @param Node\AttributeGroup $attributeGroup
+     *
+     * @return $this The builder instance (for fluid interface)
+     */
+    public function addAttributeGroup(Node\AttributeGroup $attributeGroup) {
+        $this->attributeGroups[] = $attributeGroup;
+
+        return $this;
+    }
+
+    /**
      * Returns the built class node.
      *
      * @return Stmt\Property The built property node
@@ -126,7 +143,8 @@ class Property implements PhpParser\Builder
                 new Stmt\PropertyProperty($this->name, $this->default)
             ],
             $this->attributes,
-            $this->type
+            $this->type,
+            $this->attributeGroups
         );
     }
 }

--- a/lib/PhpParser/Builder/Property.php
+++ b/lib/PhpParser/Builder/Property.php
@@ -119,7 +119,7 @@ class Property implements PhpParser\Builder
     }
 
     /**
-     * Adds an attribute group to the constant.
+     * Adds an attribute group.
      *
      * @param Node\Attribute|Node\AttributeGroup $attribute
      *

--- a/lib/PhpParser/Builder/Trait_.php
+++ b/lib/PhpParser/Builder/Trait_.php
@@ -4,6 +4,7 @@ namespace PhpParser\Builder;
 
 use PhpParser;
 use PhpParser\BuilderHelpers;
+use PhpParser\Node;
 use PhpParser\Node\Stmt;
 
 class Trait_ extends Declaration
@@ -12,6 +13,9 @@ class Trait_ extends Declaration
     protected $uses = [];
     protected $properties = [];
     protected $methods = [];
+
+    /** @var Node\AttributeGroup[] */
+    protected $attributeGroups = [];
 
     /**
      * Creates an interface builder.
@@ -46,6 +50,19 @@ class Trait_ extends Declaration
     }
 
     /**
+     * Adds an attribute group to the constant.
+     *
+     * @param Node\AttributeGroup $attributeGroup
+     *
+     * @return $this The builder instance (for fluid interface)
+     */
+    public function addAttributeGroup(Node\AttributeGroup $attributeGroup) {
+        $this->attributeGroups[] = $attributeGroup;
+
+        return $this;
+    }
+
+    /**
      * Returns the built trait node.
      *
      * @return Stmt\Trait_ The built interface node
@@ -53,7 +70,8 @@ class Trait_ extends Declaration
     public function getNode() : PhpParser\Node {
         return new Stmt\Trait_(
             $this->name, [
-                'stmts' => array_merge($this->uses, $this->properties, $this->methods)
+                'stmts' => array_merge($this->uses, $this->properties, $this->methods),
+                'attrGroups' => $this->attributeGroups,
             ], $this->attributes
         );
     }

--- a/lib/PhpParser/Builder/Trait_.php
+++ b/lib/PhpParser/Builder/Trait_.php
@@ -52,12 +52,12 @@ class Trait_ extends Declaration
     /**
      * Adds an attribute group to the constant.
      *
-     * @param Node\AttributeGroup $attributeGroup
+     * @param Node\Attribute|Node\AttributeGroup $attribute
      *
      * @return $this The builder instance (for fluid interface)
      */
-    public function addAttributeGroup(Node\AttributeGroup $attributeGroup) {
-        $this->attributeGroups[] = $attributeGroup;
+    public function addAttribute($attribute) {
+        $this->attributeGroups[] = BuilderHelpers::normalizeAttribute($attribute);
 
         return $this;
     }

--- a/lib/PhpParser/Builder/Trait_.php
+++ b/lib/PhpParser/Builder/Trait_.php
@@ -50,7 +50,7 @@ class Trait_ extends Declaration
     }
 
     /**
-     * Adds an attribute group to the constant.
+     * Adds an attribute group.
      *
      * @param Node\Attribute|Node\AttributeGroup $attribute
      *

--- a/lib/PhpParser/BuilderHelpers.php
+++ b/lib/PhpParser/BuilderHelpers.php
@@ -284,7 +284,7 @@ final class BuilderHelpers
         }
 
         if (!($attribute instanceof Node\Attribute)) {
-            throw new \LogicException('Attribute must be an instance of PhpParser\Comment\Attribute or PhpParser\Comment\AttributeGroup');
+            throw new \LogicException('Attribute must be an instance of PhpParser\Node\Attribute or PhpParser\Node\AttributeGroup');
         }
 
         return new Node\AttributeGroup([$attribute]);

--- a/lib/PhpParser/BuilderHelpers.php
+++ b/lib/PhpParser/BuilderHelpers.php
@@ -271,6 +271,26 @@ final class BuilderHelpers
     }
 
     /**
+     * Normalizes a attribute: Converts attribute to the Attribute Group if needed.
+     *
+     * @param Node\Attribute|Node\AttributeGroup $attribute
+     *
+     * @return Node\AttributeGroup The Attribute Group
+     */
+    public static function normalizeAttribute($attribute) : Node\AttributeGroup
+    {
+        if ($attribute instanceof Node\AttributeGroup) {
+            return $attribute;
+        }
+
+        if (!($attribute instanceof Node\Attribute)) {
+            throw new \LogicException('Attribute must be an instance of PhpParser\Comment\Attribute or PhpParser\Comment\AttributeGroup');
+        }
+
+        return new Node\AttributeGroup([$attribute]);
+    }
+
+    /**
      * Adds a modifier and returns new modifier bitmask.
      *
      * @param int $modifiers Existing modifiers

--- a/test/PhpParser/Builder/ClassConstTest.php
+++ b/test/PhpParser/Builder/ClassConstTest.php
@@ -103,7 +103,7 @@ class ClassConstTest extends \PHPUnit\Framework\TestCase
         );
     }
 
-    public function testAddAttributeGroup() {
+    public function testAddAttribute() {
         $attribute = new Attribute(
             new Name('Attr'),
             [new Arg(new LNumber(1), false, false, [], new Identifier('name'))]
@@ -111,7 +111,7 @@ class ClassConstTest extends \PHPUnit\Framework\TestCase
         $attributeGroup = new AttributeGroup([$attribute]);
 
         $node = $this->createClassConstBuilder('ATTR_GROUP', 1)
-            ->addAttributeGroup($attributeGroup)
+            ->addAttribute($attributeGroup)
             ->getNode();
 
         $this->assertEquals(

--- a/test/PhpParser/Builder/ClassConstTest.php
+++ b/test/PhpParser/Builder/ClassConstTest.php
@@ -3,8 +3,12 @@
 namespace PhpParser\Builder;
 
 use PhpParser\Comment;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Attribute;
+use PhpParser\Node\AttributeGroup;
 use PhpParser\Node\Const_;
 use PhpParser\Node\Expr;
+use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
 use PhpParser\Node\Scalar;
 use PhpParser\Node\Scalar\LNumber;
@@ -94,6 +98,30 @@ class ClassConstTest extends \PHPUnit\Framework\TestCase
                     new Const_("FIRST_TEST", new LNumber(1)),
                     new Const_("SECOND_TEST", new LNumber(2))
                 ]
+            ),
+            $node
+        );
+    }
+
+    public function testAddAttributeGroup() {
+        $attribute = new Attribute(
+            new Name('Attr'),
+            [new Arg(new LNumber(1), false, false, [], new Identifier('name'))]
+        );
+        $attributeGroup = new AttributeGroup([$attribute]);
+
+        $node = $this->createClassConstBuilder('ATTR_GROUP', 1)
+            ->addAttributeGroup($attributeGroup)
+            ->getNode();
+
+        $this->assertEquals(
+            new Stmt\ClassConst(
+                [
+                    new Const_("ATTR_GROUP", new LNumber(1) )
+                ],
+                0,
+                [],
+                [$attributeGroup]
             ),
             $node
         );

--- a/test/PhpParser/Builder/ClassTest.php
+++ b/test/PhpParser/Builder/ClassTest.php
@@ -127,7 +127,7 @@ DOC;
         );
     }
 
-    public function testAddAttributeGroup() {
+    public function testAddAttribute() {
         $attribute = new Attribute(
             new Name('Attr'),
             [new Arg(new LNumber(1), false, false, [], new Identifier('name'))]
@@ -135,7 +135,7 @@ DOC;
         $attributeGroup = new AttributeGroup([$attribute]);
 
         $class = $this->createClassBuilder('ATTR_GROUP')
-            ->addAttributeGroup($attributeGroup)
+            ->addAttribute($attributeGroup)
             ->getNode();
 
         $this->assertEquals(

--- a/test/PhpParser/Builder/ClassTest.php
+++ b/test/PhpParser/Builder/ClassTest.php
@@ -4,7 +4,12 @@ namespace PhpParser\Builder;
 
 use PhpParser\Comment;
 use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Attribute;
+use PhpParser\Node\AttributeGroup;
+use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
+use PhpParser\Node\Scalar\LNumber;
 use PhpParser\Node\Stmt;
 
 class ClassTest extends \PHPUnit\Framework\TestCase
@@ -118,6 +123,27 @@ DOC;
                     new Comment\Doc($docComment)
                 ]
             ]),
+            $class
+        );
+    }
+
+    public function testAddAttributeGroup() {
+        $attribute = new Attribute(
+            new Name('Attr'),
+            [new Arg(new LNumber(1), false, false, [], new Identifier('name'))]
+        );
+        $attributeGroup = new AttributeGroup([$attribute]);
+
+        $class = $this->createClassBuilder('ATTR_GROUP')
+            ->addAttributeGroup($attributeGroup)
+            ->getNode();
+
+        $this->assertEquals(
+            new Stmt\Class_('ATTR_GROUP', [
+                'attrGroups' => [
+                    $attributeGroup,
+                ]
+            ], []),
             $class
         );
     }

--- a/test/PhpParser/Builder/FunctionTest.php
+++ b/test/PhpParser/Builder/FunctionTest.php
@@ -87,7 +87,7 @@ class FunctionTest extends \PHPUnit\Framework\TestCase
         ]), $node);
     }
 
-    public function testAddAttributeGroup() {
+    public function testAddAttribute() {
         $attribute = new Attribute(
             new Name('Attr'),
             [new Arg(new LNumber(1), false, false, [], new Identifier('name'))]
@@ -95,7 +95,7 @@ class FunctionTest extends \PHPUnit\Framework\TestCase
         $attributeGroup = new AttributeGroup([$attribute]);
 
         $node = $this->createFunctionBuilder('attrGroup')
-            ->addAttributeGroup($attributeGroup)
+            ->addAttribute($attributeGroup)
             ->getNode();
 
         $this->assertEquals(new Stmt\Function_('attrGroup', [

--- a/test/PhpParser/Builder/FunctionTest.php
+++ b/test/PhpParser/Builder/FunctionTest.php
@@ -4,8 +4,14 @@ namespace PhpParser\Builder;
 
 use PhpParser\Comment;
 use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Attribute;
+use PhpParser\Node\AttributeGroup;
 use PhpParser\Node\Expr\Print_;
 use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use PhpParser\Node\Scalar\LNumber;
 use PhpParser\Node\Scalar\String_;
 use PhpParser\Node\Stmt;
 
@@ -79,6 +85,22 @@ class FunctionTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(new Stmt\Function_('test', [], [
             'comments' => [new Comment\Doc('/** Test */')]
         ]), $node);
+    }
+
+    public function testAddAttributeGroup() {
+        $attribute = new Attribute(
+            new Name('Attr'),
+            [new Arg(new LNumber(1), false, false, [], new Identifier('name'))]
+        );
+        $attributeGroup = new AttributeGroup([$attribute]);
+
+        $node = $this->createFunctionBuilder('attrGroup')
+            ->addAttributeGroup($attributeGroup)
+            ->getNode();
+
+        $this->assertEquals(new Stmt\Function_('attrGroup', [
+            'attrGroups' => [$attributeGroup],
+        ], []), $node);
     }
 
     public function testReturnType() {

--- a/test/PhpParser/Builder/InterfaceTest.php
+++ b/test/PhpParser/Builder/InterfaceTest.php
@@ -82,7 +82,7 @@ class InterfaceTest extends \PHPUnit\Framework\TestCase
         ]), $node);
     }
 
-    public function testAddAttributeGroup() {
+    public function testAddAttribute() {
         $attribute = new Attribute(
             new Name('Attr'),
             [new Arg(new LNumber(1), false, false, [], new Identifier('name'))]
@@ -90,7 +90,7 @@ class InterfaceTest extends \PHPUnit\Framework\TestCase
         $attributeGroup = new AttributeGroup([$attribute]);
 
         $node = $this->createInterfaceBuilder()
-            ->addAttributeGroup($attributeGroup)
+            ->addAttribute($attributeGroup)
             ->getNode();
 
         $this->assertEquals(new Stmt\Interface_('Contract', [

--- a/test/PhpParser/Builder/InterfaceTest.php
+++ b/test/PhpParser/Builder/InterfaceTest.php
@@ -4,7 +4,13 @@ namespace PhpParser\Builder;
 
 use PhpParser\Comment;
 use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Attribute;
+use PhpParser\Node\AttributeGroup;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
 use PhpParser\Node\Scalar\DNumber;
+use PhpParser\Node\Scalar\LNumber;
 use PhpParser\Node\Stmt;
 
 class InterfaceTest extends \PHPUnit\Framework\TestCase
@@ -74,6 +80,22 @@ class InterfaceTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(new Stmt\Interface_('Contract', [], [
             'comments' => [new Comment\Doc('/** Test */')]
         ]), $node);
+    }
+
+    public function testAddAttributeGroup() {
+        $attribute = new Attribute(
+            new Name('Attr'),
+            [new Arg(new LNumber(1), false, false, [], new Identifier('name'))]
+        );
+        $attributeGroup = new AttributeGroup([$attribute]);
+
+        $node = $this->createInterfaceBuilder()
+            ->addAttributeGroup($attributeGroup)
+            ->getNode();
+
+        $this->assertEquals(new Stmt\Interface_('Contract', [
+            'attrGroups' => [$attributeGroup],
+        ], []), $node);
     }
 
     public function testInvalidStmtError() {

--- a/test/PhpParser/Builder/MethodTest.php
+++ b/test/PhpParser/Builder/MethodTest.php
@@ -131,7 +131,7 @@ class MethodTest extends \PHPUnit\Framework\TestCase
         ]), $node);
     }
 
-    public function testAddAttributeGroup() {
+    public function testAddAttribute() {
         $attribute = new Attribute(
             new Name('Attr'),
             [new Arg(new LNumber(1), false, false, [], new Identifier('name'))]
@@ -139,7 +139,7 @@ class MethodTest extends \PHPUnit\Framework\TestCase
         $attributeGroup = new AttributeGroup([$attribute]);
 
         $node = $this->createMethodBuilder('attributeGroup')
-            ->addAttributeGroup($attributeGroup)
+            ->addAttribute($attributeGroup)
             ->getNode();
 
         $this->assertEquals(new Stmt\ClassMethod('attributeGroup', [

--- a/test/PhpParser/Builder/MethodTest.php
+++ b/test/PhpParser/Builder/MethodTest.php
@@ -4,8 +4,14 @@ namespace PhpParser\Builder;
 
 use PhpParser\Comment;
 use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Attribute;
+use PhpParser\Node\AttributeGroup;
 use PhpParser\Node\Expr\Print_;
 use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use PhpParser\Node\Scalar\LNumber;
 use PhpParser\Node\Scalar\String_;
 use PhpParser\Node\Stmt;
 
@@ -123,6 +129,22 @@ class MethodTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(new Stmt\ClassMethod('test', [], [
             'comments' => [new Comment\Doc('/** Test */')]
         ]), $node);
+    }
+
+    public function testAddAttributeGroup() {
+        $attribute = new Attribute(
+            new Name('Attr'),
+            [new Arg(new LNumber(1), false, false, [], new Identifier('name'))]
+        );
+        $attributeGroup = new AttributeGroup([$attribute]);
+
+        $node = $this->createMethodBuilder('attributeGroup')
+            ->addAttributeGroup($attributeGroup)
+            ->getNode();
+
+        $this->assertEquals(new Stmt\ClassMethod('attributeGroup', [
+            'attrGroups' => [$attributeGroup],
+        ], []), $node);
     }
 
     public function testReturnType() {

--- a/test/PhpParser/Builder/ParamTest.php
+++ b/test/PhpParser/Builder/ParamTest.php
@@ -205,7 +205,7 @@ class ParamTest extends \PHPUnit\Framework\TestCase
         );
     }
 
-    public function testAddAttributeGroup() {
+    public function testAddAttribute() {
         $attribute = new Attribute(
             new Name('Attr'),
             [new Arg(new LNumber(1), false, false, [], new Identifier('name'))]
@@ -213,7 +213,7 @@ class ParamTest extends \PHPUnit\Framework\TestCase
         $attributeGroup = new AttributeGroup([$attribute]);
 
         $node = $this->createParamBuilder('attributeGroup')
-            ->addAttributeGroup($attributeGroup)
+            ->addAttribute($attributeGroup)
             ->getNode();
 
         $this->assertEquals(

--- a/test/PhpParser/Builder/ParamTest.php
+++ b/test/PhpParser/Builder/ParamTest.php
@@ -3,8 +3,14 @@
 namespace PhpParser\Builder;
 
 use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Attribute;
+use PhpParser\Node\AttributeGroup;
 use PhpParser\Node\Expr;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
 use PhpParser\Node\Scalar;
+use PhpParser\Node\Scalar\LNumber;
 
 class ParamTest extends \PHPUnit\Framework\TestCase
 {
@@ -195,6 +201,23 @@ class ParamTest extends \PHPUnit\Framework\TestCase
 
         $this->assertEquals(
             new Node\Param(new Expr\Variable('test'), null, null, false, true),
+            $node
+        );
+    }
+
+    public function testAddAttributeGroup() {
+        $attribute = new Attribute(
+            new Name('Attr'),
+            [new Arg(new LNumber(1), false, false, [], new Identifier('name'))]
+        );
+        $attributeGroup = new AttributeGroup([$attribute]);
+
+        $node = $this->createParamBuilder('attributeGroup')
+            ->addAttributeGroup($attributeGroup)
+            ->getNode();
+
+        $this->assertEquals(
+            new Node\Param(new Expr\Variable('attributeGroup'), null, null, false, false, [], 0, [$attributeGroup]),
             $node
         );
     }

--- a/test/PhpParser/Builder/PropertyTest.php
+++ b/test/PhpParser/Builder/PropertyTest.php
@@ -3,9 +3,14 @@
 namespace PhpParser\Builder;
 
 use PhpParser\Comment;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Attribute;
+use PhpParser\Node\AttributeGroup;
 use PhpParser\Node\Expr;
+use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
 use PhpParser\Node\Scalar;
+use PhpParser\Node\Scalar\LNumber;
 use PhpParser\Node\Stmt;
 
 class PropertyTest extends \PHPUnit\Framework\TestCase
@@ -89,6 +94,32 @@ class PropertyTest extends \PHPUnit\Framework\TestCase
         ;
 
         $this->assertEquals($expectedValueNode, $node->props[0]->default);
+    }
+
+    public function testAddAttributeGroup() {
+        $attribute = new Attribute(
+            new Name('Attr'),
+            [new Arg(new LNumber(1), false, false, [], new Identifier('name'))]
+        );
+        $attributeGroup = new AttributeGroup([$attribute]);
+
+        $node = $this->createPropertyBuilder('test')
+            ->addAttributeGroup($attributeGroup)
+            ->getNode()
+        ;
+
+        $this->assertEquals(
+            new Stmt\Property(
+                Stmt\Class_::MODIFIER_PUBLIC,
+                [
+                    new Stmt\PropertyProperty('test')
+                ],
+                [],
+                null,
+                [$attributeGroup]
+            ),
+            $node
+        );
     }
 
     public function provideTestDefaultValues() {

--- a/test/PhpParser/Builder/PropertyTest.php
+++ b/test/PhpParser/Builder/PropertyTest.php
@@ -96,7 +96,7 @@ class PropertyTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($expectedValueNode, $node->props[0]->default);
     }
 
-    public function testAddAttributeGroup() {
+    public function testAddAttribute() {
         $attribute = new Attribute(
             new Name('Attr'),
             [new Arg(new LNumber(1), false, false, [], new Identifier('name'))]
@@ -104,7 +104,7 @@ class PropertyTest extends \PHPUnit\Framework\TestCase
         $attributeGroup = new AttributeGroup([$attribute]);
 
         $node = $this->createPropertyBuilder('test')
-            ->addAttributeGroup($attributeGroup)
+            ->addAttribute($attributeGroup)
             ->getNode()
         ;
 

--- a/test/PhpParser/Builder/TraitTest.php
+++ b/test/PhpParser/Builder/TraitTest.php
@@ -3,7 +3,12 @@
 namespace PhpParser\Builder;
 
 use PhpParser\Comment;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Attribute;
+use PhpParser\Node\AttributeGroup;
+use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
+use PhpParser\Node\Scalar\LNumber;
 use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassConst;
@@ -87,5 +92,28 @@ class TraitTest extends \PHPUnit\Framework\TestCase
         ]);
 
         $this->assertSame($properties, $trait->getProperties());
+    }
+
+    public function testAddAttributeGroup() {
+        $attribute = new Attribute(
+            new Name('Attr'),
+            [new Arg(new LNumber(1), false, false, [], new Identifier('name'))]
+        );
+        $attributeGroup = new AttributeGroup([$attribute]);
+
+        $node = $this->createTraitBuilder('AttributeGroup')
+            ->addAttributeGroup($attributeGroup)
+            ->getNode()
+        ;
+
+        $this->assertEquals(
+            new Stmt\Trait_(
+                'AttributeGroup',
+                [
+                    'attrGroups' => [$attributeGroup],
+                ]
+            ),
+            $node
+        );
     }
 }

--- a/test/PhpParser/Builder/TraitTest.php
+++ b/test/PhpParser/Builder/TraitTest.php
@@ -94,7 +94,7 @@ class TraitTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($properties, $trait->getProperties());
     }
 
-    public function testAddAttributeGroup() {
+    public function testAddAttribute() {
         $attribute = new Attribute(
             new Name('Attr'),
             [new Arg(new LNumber(1), false, false, [], new Identifier('name'))]
@@ -102,7 +102,7 @@ class TraitTest extends \PHPUnit\Framework\TestCase
         $attributeGroup = new AttributeGroup([$attribute]);
 
         $node = $this->createTraitBuilder('AttributeGroup')
-            ->addAttributeGroup($attributeGroup)
+            ->addAttribute($attributeGroup)
             ->getNode()
         ;
 

--- a/test/PhpParser/BuilderHelpersTest.php
+++ b/test/PhpParser/BuilderHelpersTest.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types=1);
+
+namespace PhpParser;
+
+use PhpParser\Node\Attribute;
+use PhpParser\Node\AttributeGroup;
+use PhpParser\Node\Name;
+
+class BuilderHelpersTest extends \PHPUnit\Framework\TestCase
+{
+    public function testNormalizeAttribute() {
+        $attribute = new Attribute(new Name('Test'));
+        $attributeGroup = new AttributeGroup([$attribute]);
+
+        $this->assertEquals($attributeGroup, BuilderHelpers::normalizeAttribute($attribute));
+        $this->assertSame($attributeGroup, BuilderHelpers::normalizeAttribute($attributeGroup));
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Attribute must be an instance of PhpParser\Comment\Attribute or PhpParser\Comment\AttributeGroup');
+        BuilderHelpers::normalizeAttribute('test');
+    }
+}

--- a/test/PhpParser/BuilderHelpersTest.php
+++ b/test/PhpParser/BuilderHelpersTest.php
@@ -16,7 +16,7 @@ class BuilderHelpersTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($attributeGroup, BuilderHelpers::normalizeAttribute($attributeGroup));
 
         $this->expectException(\LogicException::class);
-        $this->expectExceptionMessage('Attribute must be an instance of PhpParser\Comment\Attribute or PhpParser\Comment\AttributeGroup');
+        $this->expectExceptionMessage('Attribute must be an instance of PhpParser\Node\Attribute or PhpParser\Node\AttributeGroup');
         BuilderHelpers::normalizeAttribute('test');
     }
 }


### PR DESCRIPTION
Adds `addAttribute()` method to Builders of all nodes supporting attributes with `BuilderHelpers::normalizeAttribute()` usage inside so we can pass both `Node\Attribute` and `Node\AttributeGroup` instances