### PR TITLE
Add BuilderFactory::nullableType()

### DIFF
--- a/lib/PhpParser/BuilderFactory.php
+++ b/lib/PhpParser/BuilderFactory.php
@@ -360,6 +360,36 @@ class BuilderFactory
     }
 
     /**
+     * Creates a Nullable Type out of a non-normalized type
+     *
+     * @param string|Name|Identifier|Node\NullableType $type
+     *
+     * @return Node\NullableType
+     */
+    public function nullableType($type) : Node\NullableType {
+        if ($type instanceof Node\NullableType) {
+            return $type;
+        }
+
+        if (!is_string($type) && !($type instanceof Name) && !($type instanceof Identifier)) {
+            throw new \LogicException('Type must be a string, or an instance of Name, Identifier or NullableType');
+        }
+
+        if (strlen($type) > 0 && $type[0] === '?') {
+            $type = substr($type, 1);
+        }
+
+        $notNullableTypes = [
+            'void', 'mixed', 'never',
+        ];
+        if (in_array((string) $type, $notNullableTypes)) {
+            throw new \LogicException(sprintf('%s type cannot be nullable', $type));
+        }
+
+        return new Node\NullableType(BuilderHelpers::normalizeType($type));
+    }
+
+    /**
      * @param string|Expr $expr
      * @return Expr
      */

--- a/test/PhpParser/BuilderFactoryTest.php
+++ b/test/PhpParser/BuilderFactoryTest.php
@@ -262,6 +262,53 @@ class BuilderFactoryTest extends \PHPUnit\Framework\TestCase
         (new BuilderFactory())->var(new Node\Stmt\Return_());
     }
 
+    public function testNullableType() {
+        $builderFactory = new BuilderFactory();
+        $this->assertEquals(new Node\NullableType(new Node\Identifier('array')), $builderFactory->nullableType('array'));
+        $this->assertEquals(new Node\NullableType(new Node\Identifier('callable')), $builderFactory->nullableType('callable'));
+        $this->assertEquals(new Node\NullableType(new Node\Identifier('string')), $builderFactory->nullableType('string'));
+        $this->assertEquals(new Node\NullableType(new Node\Identifier('int')), $builderFactory->nullableType('int'));
+        $this->assertEquals(new Node\NullableType(new Node\Identifier('float')), $builderFactory->nullableType('float'));
+        $this->assertEquals(new Node\NullableType(new Node\Identifier('bool')), $builderFactory->nullableType('bool'));
+        $this->assertEquals(new Node\NullableType(new Node\Identifier('iterable')), $builderFactory->nullableType('iterable'));
+        $this->assertEquals(new Node\NullableType(new Node\Identifier('object')), $builderFactory->nullableType('object'));
+        $this->assertEquals(new Node\NullableType(new Node\Identifier('object')), $builderFactory->nullableType('?object'));
+
+        $intIdentifier = new Node\Identifier('int');
+        $intIdentifierNullable = new Node\NullableType($intIdentifier);
+        $intIdentifierDone = $builderFactory->nullableType($intIdentifierNullable);
+        $this->assertSame($intIdentifierNullable, $intIdentifierDone);
+        $this->assertSame($intIdentifier, $intIdentifierDone->type);
+
+        $intName = new Node\Name('int');
+        $intNameNullable = new Node\NullableType($intName);
+        $intNameDone = $builderFactory->nullableType($intNameNullable);
+        $this->assertSame($intNameNullable, $intNameDone);
+        $this->assertSame($intName, $intNameDone->type);
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Type must be a string, or an instance of Name, Identifier or NullableType');
+        $builderFactory->nullableType(new Node\UnionType(['int', 'string']));
+    }
+
+    public function testNullableTypeNullableVoid() {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('void type cannot be nullable');
+        (new BuilderFactory())->nullableType('void');
+    }
+
+    public function testNullableTypeNullableMixed() {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('mixed type cannot be nullable');
+        (new BuilderFactory())->nullableType('mixed');
+    }
+
+    public function testNullableTypeNullableNever() {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('never type cannot be nullable');
+        (new BuilderFactory())->nullableType('never');
+    }
+
     public function testIntegration() {
         $factory = new BuilderFactory;
         $node = $factory->namespace('Name\Space')


### PR DESCRIPTION
As @nikic mentioned in the #788 it would be nice if nullable types could be handled in the BuilderFactory as their own function instead of additional checks in `BuilderHelpers::normalizeType()`. This is the first step to removing that support: providing an alternative. 

Later, we could deprecate `NullableType|UnionType` param types for `BuilderHelpers::normalizeType()` and remove it altogether in the next major version (e.g. 5). 