### PR TITLE
[PrettyPrinter] Failing test Pretty Printer should not duplicate comment

### DIFF
--- a/test/code/prettyPrinter/comments.test
+++ b/test/code/prettyPrinter/comments.test
@@ -65,3 +65,27 @@ function test()
 {
     // empty
 }
+-----
+<?php
+
+function noDuplicateComment()
+{
+    if ( true ) :
+        // TEST 1
+      elseif ( true ) :
+        // TEST 2
+        // TEST 3
+        // TEST 4
+      endif;
+}
+-----
+function noDuplicateComment()
+{
+    if (true) {
+        // TEST 1
+    } elseif (true) {
+        // TEST 2
+        // TEST 3
+        // TEST 4
+    }
+}


### PR DESCRIPTION
Given the following code:

```php
    if ( true ) :
        // TEST 1
      elseif ( true ) :
        // TEST 2
        // TEST 3
        // TEST 4
      endif;
```

It currently print back:

```diff
    if (true) {
        // TEST 1
    } elseif (true) {
        // TEST 2
        // TEST 3
        // TEST 4
+       // TEST 2
+       // TEST 3
+       // TEST 4
    }
```

which duplicate on elseif part.
