### PR TITLE
Print comma before comments for new array item (fixes #804)

### DIFF
--- a/lib/PhpParser/PrettyPrinterAbstract.php
+++ b/lib/PhpParser/PrettyPrinterAbstract.php
@@ -824,7 +824,11 @@ abstract class PrettyPrinterAbstract
                     return null;
                 }
 
-                if ($insertStr === ', ' && $this->isMultiline($origNodes)) {
+                // We go multiline if the original code was multiline,
+                // or if it's an array item with a comment above it.
+                if ($insertStr === ', ' && (
+                        $this->isMultiline($origNodes) || !empty($arrItem->getAttribute('comments')))
+                ) {
                     $insertStr = ',';
                     $insertNewline = true;
                 }

--- a/lib/PhpParser/PrettyPrinterAbstract.php
+++ b/lib/PhpParser/PrettyPrinterAbstract.php
@@ -842,11 +842,11 @@ abstract class PrettyPrinterAbstract
                 $this->setIndentLevel($lastElemIndentLevel);
 
                 if ($insertNewline) {
+                    $result .= $insertStr . $this->nl;
                     $comments = $arrItem->getComments();
                     if ($comments) {
-                        $result .= $this->nl . $this->pComments($comments);
+                        $result .= $this->pComments($comments) . $this->nl;
                     }
-                    $result .= $insertStr . $this->nl;
                 } else {
                     $result .= $insertStr;
                 }

--- a/test/code/formatPreservation/arrayInsertionWithComments.test
+++ b/test/code/formatPreservation/arrayInsertionWithComments.test
@@ -1,0 +1,106 @@
+Inserting array item with comment
+-----
+<?php
+
+$items = [
+    'a' => 'foo',
+    'b' => 'bar',
+];
+-----
+$node = new Expr\ArrayItem(new Scalar\String_('baz'), new Scalar\String_('c'));
+$node->setAttribute('comments', [new Comment\Doc(<<<COMMENT
+/**
+ * A doc comment
+ */
+COMMENT
+)]);
+$array = $stmts[0]->expr->expr;
+$array->items[] = $node;
+-----
+<?php
+
+$items = [
+    'a' => 'foo',
+    'b' => 'bar',
+    /**
+     * A doc comment
+     */
+    'c' => 'baz',
+];
+-----
+<?php
+
+$items = [
+    'a' => 'foo',
+    'b' => 'bar',
+];
+-----
+$node = new Expr\ArrayItem(new Scalar\String_('baz'), new Scalar\String_('c'));
+$node->setAttribute('comments', [new Comment("/* Block comment */")]);
+$array = $stmts[0]->expr->expr;
+$array->items[] = $node;
+-----
+<?php
+
+$items = [
+    'a' => 'foo',
+    'b' => 'bar',
+    /* Block comment */
+    'c' => 'baz',
+];
+-----
+<?php
+
+$items = [
+    'a' => 'foo',
+    'b' => 'bar',
+];
+-----
+$node = new Expr\ArrayItem(new Scalar\String_('baz'), new Scalar\String_('c'));
+$node->setAttribute('comments', [new Comment("// Line comment")]);
+$array = $stmts[0]->expr->expr;
+$array->items[] = $node;
+-----
+<?php
+
+$items = [
+    'a' => 'foo',
+    'b' => 'bar',
+    // Line comment
+    'c' => 'baz',
+];
+-----
+<?php
+
+$items = [
+    'a' => 'foo',
+];
+-----
+$node = new Expr\ArrayItem(new Scalar\String_('bar'), new Scalar\String_('b'));
+$node->setAttribute('comments', [new Comment("// Line comment")]);
+$array = $stmts[0]->expr->expr;
+$array->items[] = $node;
+-----
+<?php
+
+$items = [
+    'a' => 'foo',
+    // Line comment
+    'b' => 'bar',
+];
+-----
+<?php
+
+$items = [];
+-----
+$node = new Expr\ArrayItem(new Scalar\String_('foo'), new Scalar\String_('a'));
+$node->setAttribute('comments', [new Comment("// Line comment")]);
+$array = $stmts[0]->expr->expr;
+$array->items[] = $node;
+-----
+<?php
+
+$items = [
+    // Line comment
+    'a' => 'foo',
+];


### PR DESCRIPTION
This fixes #804 by printing the `$insertStr` before the comments, in the case of items added to multiline arrays.