### PR TITLE
Change print order of modifiers

### DIFF
--- a/lib/PhpParser/PrettyPrinterAbstract.php
+++ b/lib/PhpParser/PrettyPrinterAbstract.php
@@ -1073,12 +1073,12 @@ abstract class PrettyPrinterAbstract
      * @return string Printed modifiers
      */
     protected function pModifiers(int $modifiers) {
-        return ($modifiers & Stmt\Class_::MODIFIER_PUBLIC    ? 'public '    : '')
+        return ($modifiers & Stmt\Class_::MODIFIER_FINAL     ? 'final '     : '')
+             . ($modifiers & Stmt\Class_::MODIFIER_ABSTRACT  ? 'abstract '  : '')
+             . ($modifiers & Stmt\Class_::MODIFIER_PUBLIC    ? 'public '    : '')
              . ($modifiers & Stmt\Class_::MODIFIER_PROTECTED ? 'protected ' : '')
              . ($modifiers & Stmt\Class_::MODIFIER_PRIVATE   ? 'private '   : '')
              . ($modifiers & Stmt\Class_::MODIFIER_STATIC    ? 'static '    : '')
-             . ($modifiers & Stmt\Class_::MODIFIER_ABSTRACT  ? 'abstract '  : '')
-             . ($modifiers & Stmt\Class_::MODIFIER_FINAL     ? 'final '     : '')
              . ($modifiers & Stmt\Class_::MODIFIER_READONLY  ? 'readonly '  : '');
     }
 

--- a/test/PhpParser/BuilderFactoryTest.php
+++ b/test/PhpParser/BuilderFactoryTest.php
@@ -361,7 +361,7 @@ abstract class SomeClass extends SomeOtherClass implements A\Few, \Interfaces
      *
      * @param SomeClass And takes a parameter
      */
-    public abstract function someMethod(SomeClass $someParam);
+    abstract public function someMethod(SomeClass $someParam);
     protected function anotherMethod(#[TaggedIterator('app.handlers')] $someParam = 'test')
     {
         print $someParam;

--- a/test/code/formatPreservation/modifierChange.test
+++ b/test/code/formatPreservation/modifierChange.test
@@ -28,7 +28,7 @@ class Bar {
     protected $foo
     = 24;
 
-    public final function
+    final public function
     foo() {}
 }
 -----

--- a/test/code/parser/stmt/class/simple.test
+++ b/test/code/parser/stmt/class/simple.test
@@ -11,7 +11,7 @@ class A extends B implements C, D {
 
     public function a() {}
     public static function b($a) {}
-    public final function c() : B {}
+    final public function c() : B {}
     protected function d() {}
     private function e() {}
 }

--- a/test/code/prettyPrinter/stmt/class.test
+++ b/test/code/prettyPrinter/stmt/class.test
@@ -41,7 +41,7 @@ class Foo extends Bar implements ABC, \DEF, namespace\GHI
     public function foo()
     {
     }
-    static abstract function bar()
+    abstract static function bar()
     {
     }
 }


### PR DESCRIPTION
(First contribution so please bare with me :) )

While looking through the issues for rector I noticed that the following error (https://github.com/rectorphp/rector/issues/6963) is caused by the printer of this package. While it is perfectly valid to have `public abstract` in the code I would argue that it makes more sense to switch them up to be `abstract public`. 

This is achieved by changing the order in which the modifiers are printed. I figured that both final and abstract could/should be printed before the the public/protected/private modifier.