### PR TITLE
[String_] Add rawValue attribute

### DIFF
--- a/grammar/php5.y
+++ b/grammar/php5.y
@@ -691,7 +691,6 @@ scalar_dereference:
       array_expr '[' dim_offset ']'                         { $$ = Expr\ArrayDimFetch[$1, $3]; }
     | T_CONSTANT_ENCAPSED_STRING '[' dim_offset ']'
           { $attrs = attributes();
-            $attrs['kind'] = strKind($1);
             $$ = Expr\ArrayDimFetch[Scalar\String_::fromString($1, $attrs), $3]; }
     | constant '[' dim_offset ']'                           { $$ = Expr\ArrayDimFetch[$1, $3]; }
     | scalar_dereference '[' dim_offset ']'                 { $$ = Expr\ArrayDimFetch[$1, $3]; }
@@ -797,7 +796,6 @@ common_scalar:
     | T_DNUMBER                                             { $$ = Scalar\DNumber::fromString($1, attributes()); }
     | T_CONSTANT_ENCAPSED_STRING
           { $attrs = attributes();
-            $attrs['kind'] = strKind($1);
             $$ = Scalar\String_::fromString($1, $attrs, false); }
     | T_LINE                                                { $$ = Scalar\MagicConst\Line[]; }
     | T_FILE                                                { $$ = Scalar\MagicConst\File[]; }

--- a/grammar/php5.y
+++ b/grammar/php5.y
@@ -692,8 +692,7 @@ scalar_dereference:
     | T_CONSTANT_ENCAPSED_STRING '[' dim_offset ']'
           { $attrs = attributes();
             $attrs['kind'] = strKind($1);
-            $attrs['rawValue'] = $1;
-            $$ = Expr\ArrayDimFetch[new Scalar\String_(Scalar\String_::parse($1), $attrs), $3]; }
+            $$ = Expr\ArrayDimFetch[Scalar\String_::fromString($1, $attrs), $3]; }
     | constant '[' dim_offset ']'                           { $$ = Expr\ArrayDimFetch[$1, $3]; }
     | scalar_dereference '[' dim_offset ']'                 { $$ = Expr\ArrayDimFetch[$1, $3]; }
     /* alternative array syntax missing intentionally */
@@ -799,8 +798,7 @@ common_scalar:
     | T_CONSTANT_ENCAPSED_STRING
           { $attrs = attributes();
             $attrs['kind'] = strKind($1);
-            $attrs['rawValue'] = $1;
-            $$ = new Scalar\String_(Scalar\String_::parse($1, false), $attrs); }
+            $$ = Scalar\String_::fromString($1, $attrs, false); }
     | T_LINE                                                { $$ = Scalar\MagicConst\Line[]; }
     | T_FILE                                                { $$ = Scalar\MagicConst\File[]; }
     | T_DIR                                                 { $$ = Scalar\MagicConst\Dir[]; }

--- a/grammar/php5.y
+++ b/grammar/php5.y
@@ -690,7 +690,9 @@ array_expr:
 scalar_dereference:
       array_expr '[' dim_offset ']'                         { $$ = Expr\ArrayDimFetch[$1, $3]; }
     | T_CONSTANT_ENCAPSED_STRING '[' dim_offset ']'
-          { $attrs = attributes(); $attrs['kind'] = strKind($1);
+          { $attrs = attributes();
+            $attrs['kind'] = strKind($1);
+            $attrs['rawValue'] = $1;
             $$ = Expr\ArrayDimFetch[new Scalar\String_(Scalar\String_::parse($1), $attrs), $3]; }
     | constant '[' dim_offset ']'                           { $$ = Expr\ArrayDimFetch[$1, $3]; }
     | scalar_dereference '[' dim_offset ']'                 { $$ = Expr\ArrayDimFetch[$1, $3]; }
@@ -795,8 +797,10 @@ common_scalar:
       T_LNUMBER                                             { $$ = $this->parseLNumber($1, attributes(), true); }
     | T_DNUMBER                                             { $$ = Scalar\DNumber::fromString($1, attributes()); }
     | T_CONSTANT_ENCAPSED_STRING
-          { $attrs = attributes(); $attrs['kind'] = strKind($1);
-            $$ = new Scalar\String_(Scalar\String_::parse($1, false), $attrs, $1); }
+          { $attrs = attributes();
+            $attrs['kind'] = strKind($1);
+            $attrs['rawValue'] = $1;
+            $$ = new Scalar\String_(Scalar\String_::parse($1, false), $attrs); }
     | T_LINE                                                { $$ = Scalar\MagicConst\Line[]; }
     | T_FILE                                                { $$ = Scalar\MagicConst\File[]; }
     | T_DIR                                                 { $$ = Scalar\MagicConst\Dir[]; }

--- a/grammar/php5.y
+++ b/grammar/php5.y
@@ -796,7 +796,7 @@ common_scalar:
     | T_DNUMBER                                             { $$ = Scalar\DNumber::fromString($1, attributes()); }
     | T_CONSTANT_ENCAPSED_STRING
           { $attrs = attributes(); $attrs['kind'] = strKind($1);
-            $$ = new Scalar\String_(Scalar\String_::parse($1, false), $attrs); }
+            $$ = new Scalar\String_(Scalar\String_::parse($1, false), $attrs, $1); }
     | T_LINE                                                { $$ = Scalar\MagicConst\Line[]; }
     | T_FILE                                                { $$ = Scalar\MagicConst\File[]; }
     | T_DIR                                                 { $$ = Scalar\MagicConst\Dir[]; }

--- a/grammar/php5.y
+++ b/grammar/php5.y
@@ -689,9 +689,7 @@ array_expr:
 
 scalar_dereference:
       array_expr '[' dim_offset ']'                         { $$ = Expr\ArrayDimFetch[$1, $3]; }
-    | T_CONSTANT_ENCAPSED_STRING '[' dim_offset ']'
-          { $attrs = attributes();
-            $$ = Expr\ArrayDimFetch[Scalar\String_::fromString($1, $attrs), $3]; }
+    | T_CONSTANT_ENCAPSED_STRING '[' dim_offset ']'         { $$ = Expr\ArrayDimFetch[Scalar\String_::fromString($1, attributes()), $3]; }
     | constant '[' dim_offset ']'                           { $$ = Expr\ArrayDimFetch[$1, $3]; }
     | scalar_dereference '[' dim_offset ']'                 { $$ = Expr\ArrayDimFetch[$1, $3]; }
     /* alternative array syntax missing intentionally */
@@ -794,9 +792,7 @@ ctor_arguments:
 common_scalar:
       T_LNUMBER                                             { $$ = $this->parseLNumber($1, attributes(), true); }
     | T_DNUMBER                                             { $$ = Scalar\DNumber::fromString($1, attributes()); }
-    | T_CONSTANT_ENCAPSED_STRING
-          { $attrs = attributes();
-            $$ = Scalar\String_::fromString($1, $attrs, false); }
+    | T_CONSTANT_ENCAPSED_STRING                            { $$ = Scalar\String_::fromString($1, attributes(), false); }
     | T_LINE                                                { $$ = Scalar\MagicConst\Line[]; }
     | T_FILE                                                { $$ = Scalar\MagicConst\File[]; }
     | T_DIR                                                 { $$ = Scalar\MagicConst\Dir[]; }

--- a/grammar/php7.y
+++ b/grammar/php7.y
@@ -1015,8 +1015,10 @@ dereferencable_scalar:
             $$ = new Expr\Array_($3, $attrs); }
     | array_short_syntax                                    { $$ = $1; }
     | T_CONSTANT_ENCAPSED_STRING
-          { $attrs = attributes(); $attrs['kind'] = strKind($1);
-            $$ = new Scalar\String_(Scalar\String_::parse($1), $attrs, $1); }
+          { $attrs = attributes();
+            $attrs['kind'] = strKind($1);
+            $attrs['rawValue'] = $1;
+            $$ = new Scalar\String_(Scalar\String_::parse($1), $attrs); }
     | '"' encaps_list '"'
           { $attrs = attributes(); $attrs['kind'] = Scalar\String_::KIND_DOUBLE_QUOTED;
             parseEncapsed($2, '"', true); $$ = new Scalar\Encapsed($2, $attrs); }

--- a/grammar/php7.y
+++ b/grammar/php7.y
@@ -1016,7 +1016,7 @@ dereferencable_scalar:
     | array_short_syntax                                    { $$ = $1; }
     | T_CONSTANT_ENCAPSED_STRING
           { $attrs = attributes(); $attrs['kind'] = strKind($1);
-            $$ = new Scalar\String_(Scalar\String_::parse($1), $attrs); }
+            $$ = new Scalar\String_(Scalar\String_::parse($1), $attrs, $1); }
     | '"' encaps_list '"'
           { $attrs = attributes(); $attrs['kind'] = Scalar\String_::KIND_DOUBLE_QUOTED;
             parseEncapsed($2, '"', true); $$ = new Scalar\Encapsed($2, $attrs); }

--- a/grammar/php7.y
+++ b/grammar/php7.y
@@ -1017,8 +1017,7 @@ dereferencable_scalar:
     | T_CONSTANT_ENCAPSED_STRING
           { $attrs = attributes();
             $attrs['kind'] = strKind($1);
-            $attrs['rawValue'] = $1;
-            $$ = new Scalar\String_(Scalar\String_::parse($1), $attrs); }
+            $$ = Scalar\String_::fromString($1, $attrs); }
     | '"' encaps_list '"'
           { $attrs = attributes(); $attrs['kind'] = Scalar\String_::KIND_DOUBLE_QUOTED;
             parseEncapsed($2, '"', true); $$ = new Scalar\Encapsed($2, $attrs); }

--- a/grammar/php7.y
+++ b/grammar/php7.y
@@ -1016,7 +1016,6 @@ dereferencable_scalar:
     | array_short_syntax                                    { $$ = $1; }
     | T_CONSTANT_ENCAPSED_STRING
           { $attrs = attributes();
-            $attrs['kind'] = strKind($1);
             $$ = Scalar\String_::fromString($1, $attrs); }
     | '"' encaps_list '"'
           { $attrs = attributes(); $attrs['kind'] = Scalar\String_::KIND_DOUBLE_QUOTED;

--- a/grammar/php7.y
+++ b/grammar/php7.y
@@ -1014,9 +1014,7 @@ dereferencable_scalar:
           { $attrs = attributes(); $attrs['kind'] = Expr\Array_::KIND_LONG;
             $$ = new Expr\Array_($3, $attrs); }
     | array_short_syntax                                    { $$ = $1; }
-    | T_CONSTANT_ENCAPSED_STRING
-          { $attrs = attributes();
-            $$ = Scalar\String_::fromString($1, $attrs); }
+    | T_CONSTANT_ENCAPSED_STRING                            { $$ = Scalar\String_::fromString($1, attributes()); }
     | '"' encaps_list '"'
           { $attrs = attributes(); $attrs['kind'] = Scalar\String_::KIND_DOUBLE_QUOTED;
             parseEncapsed($2, '"', true); $$ = new Scalar\Encapsed($2, $attrs); }

--- a/grammar/phpyLang.php
+++ b/grammar/phpyLang.php
@@ -128,14 +128,6 @@ function resolveMacros($code) {
                        . ' else { ' . $args[0] . ' = null; }';
             }
 
-            if ('strKind' === $name) {
-                assertArgs(1, $args, $name);
-
-                return '(' . $args[0] . '[0] === "\'" || (' . $args[0] . '[1] === "\'" && '
-                       . '(' . $args[0] . '[0] === \'b\' || ' . $args[0] . '[0] === \'B\')) '
-                       . '? Scalar\String_::KIND_SINGLE_QUOTED : Scalar\String_::KIND_DOUBLE_QUOTED)';
-            }
-
             if ('prependLeadingComments' === $name) {
                 assertArgs(1, $args, $name);
 

--- a/lib/PhpParser/Node/Scalar/String_.php
+++ b/lib/PhpParser/Node/Scalar/String_.php
@@ -47,7 +47,12 @@ class String_ extends Scalar
      */
     public static function fromString(string $str, array $attributes = [], bool $parseUnicodeEscape = true): self
     {
+        $attributes['kind'] = ($str[0] === "'" || ($str[1] === "'" && ($str[0] === 'b' || $str[0] === 'B')))
+            ? Scalar\String_::KIND_SINGLE_QUOTED
+            : Scalar\String_::KIND_DOUBLE_QUOTED;
+
         $attributes['rawValue'] = $str;
+
         $string = self::parse($str, $parseUnicodeEscape);
 
         return new self($string, $attributes);

--- a/lib/PhpParser/Node/Scalar/String_.php
+++ b/lib/PhpParser/Node/Scalar/String_.php
@@ -16,6 +16,9 @@ class String_ extends Scalar
     /** @var string String value */
     public $value;
 
+    /** @var string String raw value */
+    public $rawValue;
+
     protected static $replacements = [
         '\\' => '\\',
         '$'  =>  '$',
@@ -30,12 +33,14 @@ class String_ extends Scalar
     /**
      * Constructs a string scalar node.
      *
-     * @param string $value      Value of the string
-     * @param array  $attributes Additional attributes
+     * @param string      $value      Value of the string
+     * @param array       $attributes Additional attributes
+     * @param string|null $rawValue
      */
-    public function __construct(string $value, array $attributes = []) {
+    public function __construct(string $value, array $attributes = [], $rawValue = null) {
         $this->attributes = $attributes;
         $this->value = $value;
+        $this->rawValue = $rawValue ?? $value;
     }
 
     public function getSubNodeNames() : array {

--- a/lib/PhpParser/Node/Scalar/String_.php
+++ b/lib/PhpParser/Node/Scalar/String_.php
@@ -16,9 +16,6 @@ class String_ extends Scalar
     /** @var string String value */
     public $value;
 
-    /** @var string String raw value */
-    public $rawValue;
-
     protected static $replacements = [
         '\\' => '\\',
         '$'  =>  '$',
@@ -33,14 +30,12 @@ class String_ extends Scalar
     /**
      * Constructs a string scalar node.
      *
-     * @param string      $value      Value of the string
-     * @param array       $attributes Additional attributes
-     * @param string|null $rawValue
+     * @param string $value      Value of the string
+     * @param array  $attributes Additional attributes
      */
-    public function __construct(string $value, array $attributes = [], $rawValue = null) {
+    public function __construct(string $value, array $attributes = []) {
         $this->attributes = $attributes;
         $this->value = $value;
-        $this->rawValue = $rawValue ?? $value;
     }
 
     public function getSubNodeNames() : array {

--- a/lib/PhpParser/Node/Scalar/String_.php
+++ b/lib/PhpParser/Node/Scalar/String_.php
@@ -43,6 +43,17 @@ class String_ extends Scalar
     }
 
     /**
+     * @param bool $parseUnicodeEscape Whether to parse PHP 7 \u escapes
+     */
+    public static function fromString(string $str, array $attributes = [], bool $parseUnicodeEscape = true): self
+    {
+        $attributes['rawValue'] = $str;
+        $string = self::parse($str, $parseUnicodeEscape);
+
+        return new self($string, $attributes);
+    }
+
+    /**
      * @internal
      *
      * Parses a string token.

--- a/lib/PhpParser/Parser/Php5.php
+++ b/lib/PhpParser/Parser/Php5.php
@@ -2147,7 +2147,9 @@ class Php5 extends \PhpParser\ParserAbstract
                  $this->semValue = new Expr\ArrayDimFetch($this->semStack[$stackPos-(4-1)], $this->semStack[$stackPos-(4-3)], $this->startAttributeStack[$stackPos-(4-1)] + $this->endAttributes);
             },
             392 => function ($stackPos) {
-                 $attrs = $this->startAttributeStack[$stackPos-(4-1)] + $this->endAttributes; $attrs['kind'] = ($this->semStack[$stackPos-(4-1)][0] === "'" || ($this->semStack[$stackPos-(4-1)][1] === "'" && ($this->semStack[$stackPos-(4-1)][0] === 'b' || $this->semStack[$stackPos-(4-1)][0] === 'B')) ? Scalar\String_::KIND_SINGLE_QUOTED : Scalar\String_::KIND_DOUBLE_QUOTED);
+                 $attrs = $this->startAttributeStack[$stackPos-(4-1)] + $this->endAttributes;
+            $attrs['kind'] = ($this->semStack[$stackPos-(4-1)][0] === "'" || ($this->semStack[$stackPos-(4-1)][1] === "'" && ($this->semStack[$stackPos-(4-1)][0] === 'b' || $this->semStack[$stackPos-(4-1)][0] === 'B')) ? Scalar\String_::KIND_SINGLE_QUOTED : Scalar\String_::KIND_DOUBLE_QUOTED);
+            $attrs['rawValue'] = $this->semStack[$stackPos-(4-1)];
             $this->semValue = new Expr\ArrayDimFetch(new Scalar\String_(Scalar\String_::parse($this->semStack[$stackPos-(4-1)]), $attrs), $this->semStack[$stackPos-(4-3)], $this->startAttributeStack[$stackPos-(4-1)] + $this->endAttributes);
             },
             393 => function ($stackPos) {
@@ -2278,8 +2280,10 @@ class Php5 extends \PhpParser\ParserAbstract
                  $this->semValue = Scalar\DNumber::fromString($this->semStack[$stackPos-(1-1)], $this->startAttributeStack[$stackPos-(1-1)] + $this->endAttributes);
             },
             435 => function ($stackPos) {
-                 $attrs = $this->startAttributeStack[$stackPos-(1-1)] + $this->endAttributes; $attrs['kind'] = ($this->semStack[$stackPos-(1-1)][0] === "'" || ($this->semStack[$stackPos-(1-1)][1] === "'" && ($this->semStack[$stackPos-(1-1)][0] === 'b' || $this->semStack[$stackPos-(1-1)][0] === 'B')) ? Scalar\String_::KIND_SINGLE_QUOTED : Scalar\String_::KIND_DOUBLE_QUOTED);
-            $this->semValue = new Scalar\String_(Scalar\String_::parse($this->semStack[$stackPos-(1-1)], false), $attrs, $this->semStack[$stackPos-(1-1)]);
+                 $attrs = $this->startAttributeStack[$stackPos-(1-1)] + $this->endAttributes;
+            $attrs['kind'] = ($this->semStack[$stackPos-(1-1)][0] === "'" || ($this->semStack[$stackPos-(1-1)][1] === "'" && ($this->semStack[$stackPos-(1-1)][0] === 'b' || $this->semStack[$stackPos-(1-1)][0] === 'B')) ? Scalar\String_::KIND_SINGLE_QUOTED : Scalar\String_::KIND_DOUBLE_QUOTED);
+            $attrs['rawValue'] = $this->semStack[$stackPos-(1-1)];
+            $this->semValue = new Scalar\String_(Scalar\String_::parse($this->semStack[$stackPos-(1-1)], false), $attrs);
             },
             436 => function ($stackPos) {
                  $this->semValue = new Scalar\MagicConst\Line($this->startAttributeStack[$stackPos-(1-1)] + $this->endAttributes);

--- a/lib/PhpParser/Parser/Php5.php
+++ b/lib/PhpParser/Parser/Php5.php
@@ -2149,8 +2149,7 @@ class Php5 extends \PhpParser\ParserAbstract
             392 => function ($stackPos) {
                  $attrs = $this->startAttributeStack[$stackPos-(4-1)] + $this->endAttributes;
             $attrs['kind'] = ($this->semStack[$stackPos-(4-1)][0] === "'" || ($this->semStack[$stackPos-(4-1)][1] === "'" && ($this->semStack[$stackPos-(4-1)][0] === 'b' || $this->semStack[$stackPos-(4-1)][0] === 'B')) ? Scalar\String_::KIND_SINGLE_QUOTED : Scalar\String_::KIND_DOUBLE_QUOTED);
-            $attrs['rawValue'] = $this->semStack[$stackPos-(4-1)];
-            $this->semValue = new Expr\ArrayDimFetch(new Scalar\String_(Scalar\String_::parse($this->semStack[$stackPos-(4-1)]), $attrs), $this->semStack[$stackPos-(4-3)], $this->startAttributeStack[$stackPos-(4-1)] + $this->endAttributes);
+            $this->semValue = new Expr\ArrayDimFetch(Scalar\String_::fromString($this->semStack[$stackPos-(4-1)], $attrs), $this->semStack[$stackPos-(4-3)], $this->startAttributeStack[$stackPos-(4-1)] + $this->endAttributes);
             },
             393 => function ($stackPos) {
                  $this->semValue = new Expr\ArrayDimFetch($this->semStack[$stackPos-(4-1)], $this->semStack[$stackPos-(4-3)], $this->startAttributeStack[$stackPos-(4-1)] + $this->endAttributes);
@@ -2282,8 +2281,7 @@ class Php5 extends \PhpParser\ParserAbstract
             435 => function ($stackPos) {
                  $attrs = $this->startAttributeStack[$stackPos-(1-1)] + $this->endAttributes;
             $attrs['kind'] = ($this->semStack[$stackPos-(1-1)][0] === "'" || ($this->semStack[$stackPos-(1-1)][1] === "'" && ($this->semStack[$stackPos-(1-1)][0] === 'b' || $this->semStack[$stackPos-(1-1)][0] === 'B')) ? Scalar\String_::KIND_SINGLE_QUOTED : Scalar\String_::KIND_DOUBLE_QUOTED);
-            $attrs['rawValue'] = $this->semStack[$stackPos-(1-1)];
-            $this->semValue = new Scalar\String_(Scalar\String_::parse($this->semStack[$stackPos-(1-1)], false), $attrs);
+            $this->semValue = Scalar\String_::fromString($this->semStack[$stackPos-(1-1)], $attrs, false);
             },
             436 => function ($stackPos) {
                  $this->semValue = new Scalar\MagicConst\Line($this->startAttributeStack[$stackPos-(1-1)] + $this->endAttributes);

--- a/lib/PhpParser/Parser/Php5.php
+++ b/lib/PhpParser/Parser/Php5.php
@@ -2148,7 +2148,6 @@ class Php5 extends \PhpParser\ParserAbstract
             },
             392 => function ($stackPos) {
                  $attrs = $this->startAttributeStack[$stackPos-(4-1)] + $this->endAttributes;
-            $attrs['kind'] = ($this->semStack[$stackPos-(4-1)][0] === "'" || ($this->semStack[$stackPos-(4-1)][1] === "'" && ($this->semStack[$stackPos-(4-1)][0] === 'b' || $this->semStack[$stackPos-(4-1)][0] === 'B')) ? Scalar\String_::KIND_SINGLE_QUOTED : Scalar\String_::KIND_DOUBLE_QUOTED);
             $this->semValue = new Expr\ArrayDimFetch(Scalar\String_::fromString($this->semStack[$stackPos-(4-1)], $attrs), $this->semStack[$stackPos-(4-3)], $this->startAttributeStack[$stackPos-(4-1)] + $this->endAttributes);
             },
             393 => function ($stackPos) {
@@ -2280,7 +2279,6 @@ class Php5 extends \PhpParser\ParserAbstract
             },
             435 => function ($stackPos) {
                  $attrs = $this->startAttributeStack[$stackPos-(1-1)] + $this->endAttributes;
-            $attrs['kind'] = ($this->semStack[$stackPos-(1-1)][0] === "'" || ($this->semStack[$stackPos-(1-1)][1] === "'" && ($this->semStack[$stackPos-(1-1)][0] === 'b' || $this->semStack[$stackPos-(1-1)][0] === 'B')) ? Scalar\String_::KIND_SINGLE_QUOTED : Scalar\String_::KIND_DOUBLE_QUOTED);
             $this->semValue = Scalar\String_::fromString($this->semStack[$stackPos-(1-1)], $attrs, false);
             },
             436 => function ($stackPos) {

--- a/lib/PhpParser/Parser/Php5.php
+++ b/lib/PhpParser/Parser/Php5.php
@@ -2279,7 +2279,7 @@ class Php5 extends \PhpParser\ParserAbstract
             },
             435 => function ($stackPos) {
                  $attrs = $this->startAttributeStack[$stackPos-(1-1)] + $this->endAttributes; $attrs['kind'] = ($this->semStack[$stackPos-(1-1)][0] === "'" || ($this->semStack[$stackPos-(1-1)][1] === "'" && ($this->semStack[$stackPos-(1-1)][0] === 'b' || $this->semStack[$stackPos-(1-1)][0] === 'B')) ? Scalar\String_::KIND_SINGLE_QUOTED : Scalar\String_::KIND_DOUBLE_QUOTED);
-            $this->semValue = new Scalar\String_(Scalar\String_::parse($this->semStack[$stackPos-(1-1)], false), $attrs);
+            $this->semValue = new Scalar\String_(Scalar\String_::parse($this->semStack[$stackPos-(1-1)], false), $attrs, $this->semStack[$stackPos-(1-1)]);
             },
             436 => function ($stackPos) {
                  $this->semValue = new Scalar\MagicConst\Line($this->startAttributeStack[$stackPos-(1-1)] + $this->endAttributes);

--- a/lib/PhpParser/Parser/Php5.php
+++ b/lib/PhpParser/Parser/Php5.php
@@ -2147,8 +2147,7 @@ class Php5 extends \PhpParser\ParserAbstract
                  $this->semValue = new Expr\ArrayDimFetch($this->semStack[$stackPos-(4-1)], $this->semStack[$stackPos-(4-3)], $this->startAttributeStack[$stackPos-(4-1)] + $this->endAttributes);
             },
             392 => function ($stackPos) {
-                 $attrs = $this->startAttributeStack[$stackPos-(4-1)] + $this->endAttributes;
-            $this->semValue = new Expr\ArrayDimFetch(Scalar\String_::fromString($this->semStack[$stackPos-(4-1)], $attrs), $this->semStack[$stackPos-(4-3)], $this->startAttributeStack[$stackPos-(4-1)] + $this->endAttributes);
+                 $this->semValue = new Expr\ArrayDimFetch(Scalar\String_::fromString($this->semStack[$stackPos-(4-1)], $this->startAttributeStack[$stackPos-(4-1)] + $this->endAttributes), $this->semStack[$stackPos-(4-3)], $this->startAttributeStack[$stackPos-(4-1)] + $this->endAttributes);
             },
             393 => function ($stackPos) {
                  $this->semValue = new Expr\ArrayDimFetch($this->semStack[$stackPos-(4-1)], $this->semStack[$stackPos-(4-3)], $this->startAttributeStack[$stackPos-(4-1)] + $this->endAttributes);
@@ -2278,8 +2277,7 @@ class Php5 extends \PhpParser\ParserAbstract
                  $this->semValue = Scalar\DNumber::fromString($this->semStack[$stackPos-(1-1)], $this->startAttributeStack[$stackPos-(1-1)] + $this->endAttributes);
             },
             435 => function ($stackPos) {
-                 $attrs = $this->startAttributeStack[$stackPos-(1-1)] + $this->endAttributes;
-            $this->semValue = Scalar\String_::fromString($this->semStack[$stackPos-(1-1)], $attrs, false);
+                 $this->semValue = Scalar\String_::fromString($this->semStack[$stackPos-(1-1)], $this->startAttributeStack[$stackPos-(1-1)] + $this->endAttributes, false);
             },
             436 => function ($stackPos) {
                  $this->semValue = new Scalar\MagicConst\Line($this->startAttributeStack[$stackPos-(1-1)] + $this->endAttributes);

--- a/lib/PhpParser/Parser/Php7.php
+++ b/lib/PhpParser/Parser/Php7.php
@@ -2543,8 +2543,7 @@ class Php7 extends \PhpParser\ParserAbstract
                  $this->semValue = $this->semStack[$stackPos-(1-1)];
             },
             512 => function ($stackPos) {
-                 $attrs = $this->startAttributeStack[$stackPos-(1-1)] + $this->endAttributes;
-            $this->semValue = Scalar\String_::fromString($this->semStack[$stackPos-(1-1)], $attrs);
+                 $this->semValue = Scalar\String_::fromString($this->semStack[$stackPos-(1-1)], $this->startAttributeStack[$stackPos-(1-1)] + $this->endAttributes);
             },
             513 => function ($stackPos) {
                  $attrs = $this->startAttributeStack[$stackPos-(3-1)] + $this->endAttributes; $attrs['kind'] = Scalar\String_::KIND_DOUBLE_QUOTED;

--- a/lib/PhpParser/Parser/Php7.php
+++ b/lib/PhpParser/Parser/Php7.php
@@ -2543,8 +2543,10 @@ class Php7 extends \PhpParser\ParserAbstract
                  $this->semValue = $this->semStack[$stackPos-(1-1)];
             },
             512 => function ($stackPos) {
-                 $attrs = $this->startAttributeStack[$stackPos-(1-1)] + $this->endAttributes; $attrs['kind'] = ($this->semStack[$stackPos-(1-1)][0] === "'" || ($this->semStack[$stackPos-(1-1)][1] === "'" && ($this->semStack[$stackPos-(1-1)][0] === 'b' || $this->semStack[$stackPos-(1-1)][0] === 'B')) ? Scalar\String_::KIND_SINGLE_QUOTED : Scalar\String_::KIND_DOUBLE_QUOTED);
-            $this->semValue = new Scalar\String_(Scalar\String_::parse($this->semStack[$stackPos-(1-1)]), $attrs, $this->semStack[$stackPos-(1-1)]);
+                 $attrs = $this->startAttributeStack[$stackPos-(1-1)] + $this->endAttributes;
+            $attrs['kind'] = ($this->semStack[$stackPos-(1-1)][0] === "'" || ($this->semStack[$stackPos-(1-1)][1] === "'" && ($this->semStack[$stackPos-(1-1)][0] === 'b' || $this->semStack[$stackPos-(1-1)][0] === 'B')) ? Scalar\String_::KIND_SINGLE_QUOTED : Scalar\String_::KIND_DOUBLE_QUOTED);
+            $attrs['rawValue'] = $this->semStack[$stackPos-(1-1)];
+            $this->semValue = new Scalar\String_(Scalar\String_::parse($this->semStack[$stackPos-(1-1)]), $attrs);
             },
             513 => function ($stackPos) {
                  $attrs = $this->startAttributeStack[$stackPos-(3-1)] + $this->endAttributes; $attrs['kind'] = Scalar\String_::KIND_DOUBLE_QUOTED;

--- a/lib/PhpParser/Parser/Php7.php
+++ b/lib/PhpParser/Parser/Php7.php
@@ -2544,7 +2544,7 @@ class Php7 extends \PhpParser\ParserAbstract
             },
             512 => function ($stackPos) {
                  $attrs = $this->startAttributeStack[$stackPos-(1-1)] + $this->endAttributes; $attrs['kind'] = ($this->semStack[$stackPos-(1-1)][0] === "'" || ($this->semStack[$stackPos-(1-1)][1] === "'" && ($this->semStack[$stackPos-(1-1)][0] === 'b' || $this->semStack[$stackPos-(1-1)][0] === 'B')) ? Scalar\String_::KIND_SINGLE_QUOTED : Scalar\String_::KIND_DOUBLE_QUOTED);
-            $this->semValue = new Scalar\String_(Scalar\String_::parse($this->semStack[$stackPos-(1-1)]), $attrs);
+            $this->semValue = new Scalar\String_(Scalar\String_::parse($this->semStack[$stackPos-(1-1)]), $attrs, $this->semStack[$stackPos-(1-1)]);
             },
             513 => function ($stackPos) {
                  $attrs = $this->startAttributeStack[$stackPos-(3-1)] + $this->endAttributes; $attrs['kind'] = Scalar\String_::KIND_DOUBLE_QUOTED;

--- a/lib/PhpParser/Parser/Php7.php
+++ b/lib/PhpParser/Parser/Php7.php
@@ -2545,8 +2545,7 @@ class Php7 extends \PhpParser\ParserAbstract
             512 => function ($stackPos) {
                  $attrs = $this->startAttributeStack[$stackPos-(1-1)] + $this->endAttributes;
             $attrs['kind'] = ($this->semStack[$stackPos-(1-1)][0] === "'" || ($this->semStack[$stackPos-(1-1)][1] === "'" && ($this->semStack[$stackPos-(1-1)][0] === 'b' || $this->semStack[$stackPos-(1-1)][0] === 'B')) ? Scalar\String_::KIND_SINGLE_QUOTED : Scalar\String_::KIND_DOUBLE_QUOTED);
-            $attrs['rawValue'] = $this->semStack[$stackPos-(1-1)];
-            $this->semValue = new Scalar\String_(Scalar\String_::parse($this->semStack[$stackPos-(1-1)]), $attrs);
+            $this->semValue = Scalar\String_::fromString($this->semStack[$stackPos-(1-1)], $attrs);
             },
             513 => function ($stackPos) {
                  $attrs = $this->startAttributeStack[$stackPos-(3-1)] + $this->endAttributes; $attrs['kind'] = Scalar\String_::KIND_DOUBLE_QUOTED;

--- a/lib/PhpParser/Parser/Php7.php
+++ b/lib/PhpParser/Parser/Php7.php
@@ -2544,7 +2544,6 @@ class Php7 extends \PhpParser\ParserAbstract
             },
             512 => function ($stackPos) {
                  $attrs = $this->startAttributeStack[$stackPos-(1-1)] + $this->endAttributes;
-            $attrs['kind'] = ($this->semStack[$stackPos-(1-1)][0] === "'" || ($this->semStack[$stackPos-(1-1)][1] === "'" && ($this->semStack[$stackPos-(1-1)][0] === 'b' || $this->semStack[$stackPos-(1-1)][0] === 'B')) ? Scalar\String_::KIND_SINGLE_QUOTED : Scalar\String_::KIND_DOUBLE_QUOTED);
             $this->semValue = Scalar\String_::fromString($this->semStack[$stackPos-(1-1)], $attrs);
             },
             513 => function ($stackPos) {

--- a/test/PhpParser/Node/Scalar/StringTest.php
+++ b/test/PhpParser/Node/Scalar/StringTest.php
@@ -2,8 +2,28 @@
 
 namespace PhpParser\Node\Scalar;
 
+use PhpParser\Node\Stmt\Echo_;
+use PhpParser\ParserFactory;
+
 class StringTest extends \PHPUnit\Framework\TestCase
 {
+    public function testRawValue()
+    {
+        $parser = (new ParserFactory())->create(ParserFactory::PREFER_PHP7);
+        $nodes = $parser->parse('<?php echo "sequence \x41";');
+
+        $echo = $nodes[0];
+        $this->assertInstanceOf(Echo_::class, $echo);
+
+        /** @var Echo_ $echo */
+        $string = $echo->exprs[0];
+        $this->assertInstanceOf(String_::class, $string);
+
+        /** @var String_ $string */
+        $this->assertSame('sequence A', $string->value);
+        $this->assertSame('"sequence \\x41"', $string->rawValue);
+    }
+
     /**
      * @dataProvider provideTestParseEscapeSequences
      */

--- a/test/PhpParser/Node/Scalar/StringTest.php
+++ b/test/PhpParser/Node/Scalar/StringTest.php
@@ -21,7 +21,7 @@ class StringTest extends \PHPUnit\Framework\TestCase
 
         /** @var String_ $string */
         $this->assertSame('sequence A', $string->value);
-        $this->assertSame('"sequence \\x41"', $string->rawValue);
+        $this->assertSame('"sequence \\x41"', $string->getAttribute('rawValue'));
     }
 
     /**

--- a/test/PhpParser/NodeAbstractTest.php
+++ b/test/PhpParser/NodeAbstractTest.php
@@ -294,11 +294,11 @@ PHP;
                     {
                         "nodeType": "Scalar_String",
                         "value": "Foo",
-                        "rawValue": "'Foo'",
                         "attributes": {
                             "startLine": 5,
                             "endLine": 5,
-                            "kind": 1
+                            "kind": 1,
+                            "rawValue": "'Foo'"
                         }
                     }
                 ],
@@ -453,10 +453,10 @@ JSON;
                         "attributes": {
                             "startLine": 5,
                             "endLine": 5,
-                            "kind": 1
+                            "kind": 1,
+                            "rawValue": "'Foo'"
                         },
-                        "value": "Foo",
-                        "rawValue": "'Foo'"
+                        "value": "Foo"
                     }
                 ]
             }

--- a/test/PhpParser/NodeAbstractTest.php
+++ b/test/PhpParser/NodeAbstractTest.php
@@ -294,6 +294,7 @@ PHP;
                     {
                         "nodeType": "Scalar_String",
                         "value": "Foo",
+                        "rawValue": "'Foo'",
                         "attributes": {
                             "startLine": 5,
                             "endLine": 5,
@@ -454,7 +455,8 @@ JSON;
                             "endLine": 5,
                             "kind": 1
                         },
-                        "value": "Foo"
+                        "value": "Foo",
+                        "rawValue": "'Foo'"
                     }
                 ]
             }


### PR DESCRIPTION
In Rector we have to hack around tokens to get the original value, because the `parse()` method flattens original information:

https://github.com/nikic/PHP-Parser/blob/a6e34665fd6a2bcefc924cb5fd73788767ae510e/lib/PhpParser/Node/Scalar/String_.php#L55-L72

We could use also attribute value, but it would require more grammar changes.

Closes https://github.com/nikic/PHP-Parser/pull/577

Also fixes https://github.com/nikic/PHP-Parser/issues/576