### PR TITLE
[LNumber] Add rawValue attribute to LNumber to allow numeric separator etc.

### DIFF
--- a/lib/PhpParser/Node/Scalar/LNumber.php
+++ b/lib/PhpParser/Node/Scalar/LNumber.php
@@ -16,20 +16,15 @@ class LNumber extends Scalar
     /** @var int Number value */
     public $value;
 
-    /** @var int|string The string type is used for numeric separator, e.g. 1_000 */
-    public $rawValue;
-
     /**
      * Constructs an integer number scalar node.
      *
-     * @param int             $value      Value of the number
-     * @param array           $attributes Additional attributes
-     * @param string|int|null $rawValue
+     * @param int   $value      Value of the number
+     * @param array $attributes Additional attributes
      */
-    public function __construct(int $value, array $attributes = [], $rawValue = null) {
+    public function __construct(int $value, array $attributes = []) {
         $this->attributes = $attributes;
         $this->value = $value;
-        $this->rawValue = $rawValue ?? $value;
     }
 
     public function getSubNodeNames() : array {
@@ -46,21 +41,23 @@ class LNumber extends Scalar
      * @return LNumber The constructed LNumber, including kind attribute
      */
     public static function fromString(string $str, array $attributes = [], bool $allowInvalidOctal = false) : LNumber {
+        $attributes['rawValue'] = $str;
+
         $str = str_replace('_', '', $str);
 
         if ('0' !== $str[0] || '0' === $str) {
             $attributes['kind'] = LNumber::KIND_DEC;
-            return new LNumber((int) $str, $attributes, $str);
+            return new LNumber((int) $str, $attributes);
         }
 
         if ('x' === $str[1] || 'X' === $str[1]) {
             $attributes['kind'] = LNumber::KIND_HEX;
-            return new LNumber(hexdec($str), $attributes, $str);
+            return new LNumber(hexdec($str), $attributes);
         }
 
         if ('b' === $str[1] || 'B' === $str[1]) {
             $attributes['kind'] = LNumber::KIND_BIN;
-            return new LNumber(bindec($str), $attributes, $str);
+            return new LNumber(bindec($str), $attributes);
         }
 
         if (!$allowInvalidOctal && strpbrk($str, '89')) {
@@ -74,7 +71,7 @@ class LNumber extends Scalar
 
         // use intval instead of octdec to get proper cutting behavior with malformed numbers
         $attributes['kind'] = LNumber::KIND_OCT;
-        return new LNumber(intval($str, 8), $attributes, $str);
+        return new LNumber(intval($str, 8), $attributes);
     }
 
     public function getType() : string {

--- a/lib/PhpParser/Node/Scalar/LNumber.php
+++ b/lib/PhpParser/Node/Scalar/LNumber.php
@@ -16,15 +16,20 @@ class LNumber extends Scalar
     /** @var int Number value */
     public $value;
 
+    /** @var int|string The string type is used for numeric separator, e.g. 1_000 */
+    public $rawValue;
+
     /**
      * Constructs an integer number scalar node.
      *
-     * @param int   $value      Value of the number
-     * @param array $attributes Additional attributes
+     * @param int             $value      Value of the number
+     * @param array           $attributes Additional attributes
+     * @param string|int|null $rawValue
      */
-    public function __construct(int $value, array $attributes = []) {
+    public function __construct(int $value, array $attributes = [], $rawValue = null) {
         $this->attributes = $attributes;
         $this->value = $value;
+        $this->rawValue = $rawValue ?? $value;
     }
 
     public function getSubNodeNames() : array {
@@ -45,17 +50,17 @@ class LNumber extends Scalar
 
         if ('0' !== $str[0] || '0' === $str) {
             $attributes['kind'] = LNumber::KIND_DEC;
-            return new LNumber((int) $str, $attributes);
+            return new LNumber((int) $str, $attributes, $str);
         }
 
         if ('x' === $str[1] || 'X' === $str[1]) {
             $attributes['kind'] = LNumber::KIND_HEX;
-            return new LNumber(hexdec($str), $attributes);
+            return new LNumber(hexdec($str), $attributes, $str);
         }
 
         if ('b' === $str[1] || 'B' === $str[1]) {
             $attributes['kind'] = LNumber::KIND_BIN;
-            return new LNumber(bindec($str), $attributes);
+            return new LNumber(bindec($str), $attributes, $str);
         }
 
         if (!$allowInvalidOctal && strpbrk($str, '89')) {
@@ -69,9 +74,9 @@ class LNumber extends Scalar
 
         // use intval instead of octdec to get proper cutting behavior with malformed numbers
         $attributes['kind'] = LNumber::KIND_OCT;
-        return new LNumber(intval($str, 8), $attributes);
+        return new LNumber(intval($str, 8), $attributes, $str);
     }
-    
+
     public function getType() : string {
         return 'Scalar_LNumber';
     }

--- a/test/PhpParser/Node/Scalar/NumberTest.php
+++ b/test/PhpParser/Node/Scalar/NumberTest.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types=1);
+
+namespace PhpParser\Node\Scalar;
+
+use PhpParser\Node\Stmt\Echo_;
+use PhpParser\ParserFactory;
+
+class NumberTest extends \PHPUnit\Framework\TestCase
+{
+    public function testRawValue()
+    {
+        $parser = (new ParserFactory())->create(ParserFactory::PREFER_PHP7);
+        $nodes = $parser->parse('<?php echo 1_234;');
+
+        $echo = $nodes[0];
+        $this->assertInstanceOf(Echo_::class, $echo);
+
+        /** @var Echo_ $echo */
+        $lLumber = $echo->exprs[0];
+        $this->assertInstanceOf(LNumber::class, $lLumber);
+
+        /** @var LNumber $lnumber */
+        $this->assertSame(1234, $lLumber->value);
+        $this->assertSame('1_234', $lLumber->getAttribute('rawValue'));
+    }
+}

--- a/test/PhpParser/NodeAbstractTest.php
+++ b/test/PhpParser/NodeAbstractTest.php
@@ -242,10 +242,10 @@ PHP;
                 "default": {
                     "nodeType": "Scalar_LNumber",
                     "value": 0,
-                    "rawValue": "0",
                     "attributes": {
                         "startLine": 4,
                         "endLine": 4,
+                        "rawValue": "0",
                         "kind": 10
                     }
                 },
@@ -399,10 +399,10 @@ JSON;
                     "attributes": {
                         "startLine": 4,
                         "endLine": 4,
+                        "rawValue": "0",
                         "kind": 10
                     },
-                    "value": 0,
-                    "rawValue": "0"
+                    "value": 0
                 },
                 "flags": 0,
                 "attrGroups": []

--- a/test/PhpParser/NodeAbstractTest.php
+++ b/test/PhpParser/NodeAbstractTest.php
@@ -242,6 +242,7 @@ PHP;
                 "default": {
                     "nodeType": "Scalar_LNumber",
                     "value": 0,
+                    "rawValue": "0",
                     "attributes": {
                         "startLine": 4,
                         "endLine": 4,
@@ -400,7 +401,8 @@ JSON;
                         "endLine": 4,
                         "kind": 10
                     },
-                    "value": 0
+                    "value": 0,
+                    "rawValue": "0"
                 },
                 "flags": 0,
                 "attrGroups": []


### PR DESCRIPTION
Allows to use `$number->rawValue` to work with numberic seaprator https://github.com/nikic/PHP-Parser/pull/615

Now we have to work with actual tokens on the position to get the original value.
When accepted, I will add the same feature for `DNumber`.

Replaces https://github.com/nikic/PHP-Parser/pull/655