### PR TITLE
Short scalar cast

### DIFF
--- a/lib/PhpParser/PrettyPrinter/Standard.php
+++ b/lib/PhpParser/PrettyPrinter/Standard.php
@@ -215,7 +215,7 @@ class Standard extends PrettyPrinterAbstract
 
         // Try to find a short full-precision representation
         $stringValue = sprintf('%.16G', $node->value);
-        if ($node->value !== (double) $stringValue) {
+        if ($node->value !== (float) $stringValue) {
             $stringValue = sprintf('%.17G', $node->value);
         }
 


### PR DESCRIPTION
Cast (boolean) and (integer) should be written as (bool) and (int), (double) and (real) as (float), (binary) as (string).