### PR TITLE
Get class to class keyword

### DIFF
--- a/lib/PhpParser/Builder/Class_.php
+++ b/lib/PhpParser/Builder/Class_.php
@@ -106,7 +106,7 @@ class Class_ extends Declaration
             Stmt\ClassMethod::class => &$this->methods,
         ];
 
-        $class = \get_class($stmt);
+        $class = $stmt::class;
         if (!isset($targets[$class])) {
             throw new \LogicException(sprintf('Unexpected node of type "%s"', $stmt->getType()));
         }

--- a/lib/PhpParser/Builder/Enum_.php
+++ b/lib/PhpParser/Builder/Enum_.php
@@ -78,7 +78,7 @@ class Enum_ extends Declaration
             Stmt\ClassMethod::class => &$this->methods,
         ];
 
-        $class = \get_class($stmt);
+        $class = $stmt::class;
         if (!isset($targets[$class])) {
             throw new \LogicException(sprintf('Unexpected node of type "%s"', $stmt->getType()));
         }

--- a/lib/PhpParser/PrettyPrinterAbstract.php
+++ b/lib/PhpParser/PrettyPrinterAbstract.php
@@ -359,7 +359,7 @@ abstract class PrettyPrinterAbstract
      * @return string The pretty printed node
      */
     protected function pPrec(Node $node, int $parentPrecedence, int $parentAssociativity, int $childPosition) : string {
-        $class = \get_class($node);
+        $class = $node::class;
         if (isset($this->precedenceMap[$class])) {
             $childPrecedence = $this->precedenceMap[$class][0];
             if ($childPrecedence > $parentPrecedence
@@ -527,8 +527,8 @@ abstract class PrettyPrinterAbstract
             return $this->pFallback($node);
         }
 
-        $class = \get_class($node);
-        \assert($class === \get_class($origNode));
+        $class = $node::class;
+        \assert($class === $origNode::class);
 
         $startPos = $origNode->getStartTokenPos();
         $endPos = $origNode->getEndTokenPos();


### PR DESCRIPTION
Replace get_class calls on object variables with class keyword syntax.