### PR TITLE
Php unit dedicate assert

### DIFF
--- a/test/PhpParser/CompatibilityTest.php
+++ b/test/PhpParser/CompatibilityTest.php
@@ -8,11 +8,11 @@ class CompatibilityTest extends \PHPUnit\Framework\TestCase
 {
     public function testAliases1() {
         $node = new Node\ClosureUse(new Expr\Variable('x'));
-        $this->assertTrue($node instanceof Expr\ClosureUse);
+        $this->assertInstanceOf(Expr\ClosureUse::class, $node);
     }
 
     public function testAliases2() {
         $node = new Node\Expr\ClosureUse(new Expr\Variable('x'));
-        $this->assertTrue($node instanceof Node\ClosureUse);
+        $this->assertInstanceOf(Node\ClosureUse::class, $node);
     }
 }


### PR DESCRIPTION
PHPUnit assertions like assertInternalType, assertFileExists, should be used over assertTrue.