### PR TITLE
ParserAbstract: remove undefined class in `use`

### DIFF
--- a/lib/PhpParser/ParserAbstract.php
+++ b/lib/PhpParser/ParserAbstract.php
@@ -21,7 +21,6 @@ use PhpParser\Node\Stmt\Namespace_;
 use PhpParser\Node\Stmt\Property;
 use PhpParser\Node\Stmt\TryCatch;
 use PhpParser\Node\Stmt\UseUse;
-use PhpParser\Parser\Tokens;
 
 abstract class ParserAbstract implements Parser
 {


### PR DESCRIPTION
Class `PhpParser\Parser\Tokens` not exists in current version