### PR TITLE
Normalize comment classes

### DIFF
--- a/lib/PhpParser/Comment/Doc.php
+++ b/lib/PhpParser/Comment/Doc.php
@@ -4,4 +4,10 @@ namespace PhpParser\Comment;
 
 class Doc extends \PhpParser\Comment
 {
+    /**
+     * @inheritdoc
+     */
+    public function jsonSerialize() : array {
+        return ['nodeType' => 'Comment_Doc'] + parent::jsonSerialize();
+    }
 }


### PR DESCRIPTION
- `getReformattedText()`: fix `@return` types, remove comment trimming to keep empty lines in comment at begin and end, optimize detection of multiline comments
- `getShortestWhitespacePrefixLen()`: replace float `INF` to 0
- `jsonSerialize()`: update `@psalm-return` and remove redundant `@return`, fix `nodeType`