### PR TITLE
[docs] Add generic types to NodeFinder to allow returning exact type in static analysis

### DIFF
--- a/lib/PhpParser/NodeFinder.php
+++ b/lib/PhpParser/NodeFinder.php
@@ -31,11 +31,13 @@ class NodeFinder
 
     /**
      * Find all nodes that are instances of a certain class.
+
+     * @template TNode as Node
      *
-     * @param Node|Node[] $nodes Single node or array of nodes to search in
-     * @param string      $class Class name
+     * @param Node|Node[] $nodes    Single node or array of nodes to search in
+     * @param class-string<TNode>   $class Class name
      *
-     * @return Node[] Found nodes (all instances of $class)
+     * @return TNode[]              Found nodes (all instances of $class)
      */
     public function findInstanceOf($nodes, string $class) : array {
         return $this->find($nodes, function ($node) use ($class) {
@@ -68,10 +70,12 @@ class NodeFinder
     /**
      * Find first node that is an instance of a certain class.
      *
-     * @param Node|Node[] $nodes  Single node or array of nodes to search in
-     * @param string      $class Class name
+     * @template TNode as Node
      *
-     * @return null|Node Found node, which is an instance of $class (or null if none found)
+     * @param Node|Node[] $nodes    Single node or array of nodes to search in
+     * @param class-string<TNode>   $class Class name
+     *
+     * @return null|TNode           Found node, which is an instance of $class (or null if none found)
      */
     public function findFirstInstanceOf($nodes, string $class): ?Node {
         return $this->findFirst($nodes, function ($node) use ($class) {

--- a/lib/PhpParser/NodeFinder.php
+++ b/lib/PhpParser/NodeFinder.php
@@ -34,10 +34,10 @@ class NodeFinder
 
      * @template TNode as Node
      *
-     * @param Node|Node[] $nodes    Single node or array of nodes to search in
-     * @param class-string<TNode>   $class Class name
+     * @param Node|Node[] $nodes  Single node or array of nodes to search in
+     * @param class-string<TNode> $class Class name
      *
-     * @return TNode[]              Found nodes (all instances of $class)
+     * @return TNode[]            Found nodes (all instances of $class)
      */
     public function findInstanceOf($nodes, string $class) : array {
         return $this->find($nodes, function ($node) use ($class) {
@@ -72,10 +72,10 @@ class NodeFinder
      *
      * @template TNode as Node
      *
-     * @param Node|Node[] $nodes    Single node or array of nodes to search in
-     * @param class-string<TNode>   $class Class name
+     * @param Node|Node[] $nodes  Single node or array of nodes to search in
+     * @param class-string<TNode> $class Class name
      *
-     * @return null|TNode           Found node, which is an instance of $class (or null if none found)
+     * @return null|TNode         Found node, which is an instance of $class (or null if none found)
      */
     public function findFirstInstanceOf($nodes, string $class): ?Node {
         return $this->findFirst($nodes, function ($node) use ($class) {


### PR DESCRIPTION
At the moment, the node finder does always returns generic `Node` or `Node[]` result:

```php
$nodeFinder = new NodeFinder();

// what is it? only Node[]
$returns = $nodeFinder->typeAwareNodeFinder->findInstanceOf($node, Return_::class);
```

In fact, we know it must be instances of `Return_`. To teach IDE/static analyzer this know-how, we have to add it manually in every result:

```php
/** @var Return_[] $resturn */
$returns = $nodeFinder->typeAwareNodeFinder->findInstanceOf($node, Return_::class);
```

This PR suggest to do the same already on `php-parser` level:

![Screenshot from 2022-08-08 15-51-06](https://user-images.githubusercontent.com/924196/183434159-e33562c0-67e1-40c4-82d2-d757757dab4e.png)
