### PR TITLE
Expr\Array_ can no longer contain null as item

### DIFF
--- a/lib/PhpParser/Node/Expr/Array_.php
+++ b/lib/PhpParser/Node/Expr/Array_.php
@@ -10,13 +10,13 @@ class Array_ extends Expr
     public const KIND_LONG = 1;  // array() syntax
     public const KIND_SHORT = 2; // [] syntax
 
-    /** @var (ArrayItem|null)[] Items */
+    /** @var ArrayItem[] Items */
     public $items;
 
     /**
      * Constructs an array node.
      *
-     * @param (ArrayItem|null)[] $items      Items of the array
+     * @param ArrayItem[] $items      Items of the array
      * @param array       $attributes Additional attributes
      */
     public function __construct(array $items = [], array $attributes = []) {


### PR DESCRIPTION
After https://github.com/nikic/PHP-Parser/commit/68fc1ba4cb7b0aef9decc4e9d8f3b61eecdd3883 it's no longer possible to have `null` in this array.