### PR TITLE
Fix Token methods

### DIFF
--- a/lib/PhpParser/Token.php
+++ b/lib/PhpParser/Token.php
@@ -8,11 +8,17 @@ namespace PhpParser;
 class Token extends Internal\TokenPolyfill {
     /** Get (exclusive) zero-based end position of the token. */
     public function getEndPos(): int {
-        return $this->pos + \strlen($this->text);
+        return $this->pos < 0 ? -1 : $this->pos + \strlen($this->text);
     }
 
     /** Get 1-based end line number of the token. */
     public function getEndLine(): int {
+        if ($this->line < 1) {
+            return -1;
+        }
+        if (!isset($this->text[1])) {
+            return $this->line;
+        }
         return $this->line + \substr_count($this->text, "\n");
     }
 }


### PR DESCRIPTION
Fix result in cases when `pos` and/or `line` not set