### PR TITLE
[format-preserving] Add test for adding attribute breaks method spacing

### DIFF
--- a/test/code/formatPreservation/adding_attribute_body_space.test
+++ b/test/code/formatPreservation/adding_attribute_body_space.test
@@ -1,0 +1,25 @@
+Add attribute body space
+-----
+<?php
+
+function some()
+{
+    $value = 100;
+
+    return $value;
+}
+
+-----
+$stmts[0]->attrGroups[] = new Node\AttributeGroup([
+    new Node\Attribute(new Node\Name('B'), [])
+]);
+-----
+<?php
+
+#[B]
+function some()
+{
+    $value = 100;
+
+    return $value;
+}

--- a/test/code/formatPreservation/adding_attribute_return_type.test
+++ b/test/code/formatPreservation/adding_attribute_return_type.test
@@ -1,0 +1,19 @@
+Add attribute body space
+-----
+<?php
+
+function some() : int
+{
+}
+
+-----
+$stmts[0]->attrGroups[] = new Node\AttributeGroup([
+    new Node\Attribute(new Node\Name('B'), [])
+]);
+-----
+<?php
+
+#[B]
+function some() : int
+{
+}


### PR DESCRIPTION
Hi, we get reports in @rectorphp that adding attributes breaks the formatting of inner elements: 
https://github.com/rectorphp/rector/issues/7062

I think the issue is that original tokens do not match the new tokens position. The new tokens are added from the top, so by definition, anything bellow will be broken. Which is a pity, because people report huge classes/methods formatting removed.

There could some kind of token shift, based on newly added token count from the top. 

I looked into token printer, got a suspection about this area: https://github.com/nikic/PHP-Parser/blob/0201a7ee3f86c856eb009e1393fdd654b9667684/lib/PhpParser/PrettyPrinterAbstract.php#L564-L576
But after few trial I'm not sure how to shift tokens.

At least I'm sharing the test fixture, to verify the state. Any help/fix is appreciated :pray: 