### PR TITLE
Fix inlined add multiple attribute group

### DIFF
--- a/lib/PhpParser/PrettyPrinterAbstract.php
+++ b/lib/PhpParser/PrettyPrinterAbstract.php
@@ -925,9 +925,17 @@ abstract class PrettyPrinterAbstract
                     $result .= $insertStr;
                 }
                 $result .= $this->p($delayedAddNode, true);
+
+                if ($extraRight === "\n") {
+                    $result .= $this->nl ;
+                }
+
                 $first = false;
             }
-            $result .= $extraRight === "\n" ? $this->nl : $extraRight;
+
+            if ($extraRight !== "\n") {
+                $result .= $extraRight;
+            }
         }
 
         return $result;

--- a/test/code/formatPreservation/attributes.test
+++ b/test/code/formatPreservation/attributes.test
@@ -105,7 +105,11 @@ fn()
 $attrGroup = new Node\AttributeGroup([
     new Node\Attribute(new Node\Name('A'), []),
 ]);
+$attrGroup2 = new Node\AttributeGroup([
+    new Node\Attribute(new Node\Name('B'), []),
+]);
 $stmts[0]->attrGroups[] = $attrGroup;
+$stmts[0]->attrGroups[] = $attrGroup2;
 $stmts[0]->stmts[0]->attrGroups[] = $attrGroup;
 $stmts[0]->stmts[1]->attrGroups[] = $attrGroup;
 $stmts[0]->stmts[2]->attrGroups[] = $attrGroup;
@@ -118,6 +122,7 @@ $stmts[6]->expr->attrGroups[] = $attrGroup;
 -----
 <?php
 #[A]
+#[B]
 class X {
     #[A]
     public function m() {}


### PR DESCRIPTION
Based on https://github.com/nikic/PHP-Parser/commit/a2608f0b742b711d24de914d41c0162e37494ea6#commitcomment-82995459, the commit cause multiple attribute groups is inlined instead of multiple line. 

This PR try to fix it.