### PR TITLE
Fix pretty printing example

### DIFF
--- a/doc/component/Pretty_printing.markdown
+++ b/doc/component/Pretty_printing.markdown
@@ -80,7 +80,7 @@ $traverser->addVisitor(new NodeVisitor\CloningVisitor());
 $printer = new PrettyPrinter\Standard();
 
 $oldStmts = $parser->parse($code);
-$oldTokens = $lexer->getTokens();
+$oldTokens = $parser->getLexer()->getTokens();
 
 $newStmts = $traverser->traverse($oldStmts);
 


### PR DESCRIPTION
The `$lexer` variable no longer exist in the example.