### PR TITLE
[format preserving] Add test for removed opening PHP tag

### DIFF
--- a/test/code/formatPreservation/remove_class_method_stmts_with_inline_html.test
+++ b/test/code/formatPreservation/remove_class_method_stmts_with_inline_html.test
@@ -1,0 +1,33 @@
+Remove class method stmt with inline html
+-----
+<?php
+
+class SomeClass
+{
+    public function run()
+    {
+        echo 'hello PHP';
+
+        ?>
+        hello HTML
+        <?php
+        return;
+    }
+}
+
+-----
+unset($stmts[0]->stmts[0]->stmts[2]);
+-----
+<?php
+
+class SomeClass
+{
+    public function run()
+    {
+        echo 'hello PHP';
+
+        ?>
+        hello HTML
+        <?php
+    }
+}


### PR DESCRIPTION
It seems the removed stmt right under HTML node removes the `<?php` opening tag and crashes the code.

Reported in Rector: https://github.com/rectorphp/rector-src/pull/2909