### PR TITLE
[tests] add test where comment is not joined with the class, if with attribute

### DIFF
--- a/test/code/formatPreservation/class_with_attibute_then_annotation.test
+++ b/test/code/formatPreservation/class_with_attibute_then_annotation.test
@@ -1,0 +1,23 @@
+Class with attribute then annotation
+-----
+<?php
+
+#[SomeAttribute]
+/**
+ * @SomeAnnotation
+ */
+final class SomeClass
+{
+}
+-----
+$stmts[0]->setAttribute('comments', [new Comment("/**\n * @AnotherAnnotation\n */")]);
+-----
+<?php
+
+/**
+ * @AnotherAnnotation
+ */
+#[SomeAttribute]
+final class SomeClass
+{
+}


### PR DESCRIPTION
I tried this on Rector locally, and there is no docblock associated with the `Class_` if there is an attribute above.
Yet, the `Class_` node sees the attributes.

How can we reach it?

Reported in https://github.com/rectorphp/rector/issues/7453