### PR TITLE
[format preserving] Add test for avoid remove space inside Closure stmts when add static

### DIFF
--- a/test/code/formatPreservation/closure.test
+++ b/test/code/formatPreservation/closure.test
@@ -1,0 +1,21 @@
+Closure add static
+-----
+<?php
+function () {
+    if (rand(0, 1)) {
+        return true;
+    }
+
+    return false;
+};
+-----
+$stmts[0]->expr->static = true;
+-----
+<?php
+static function () {
+    if (rand(0, 1)) {
+        return true;
+    }
+
+    return false;
+};


### PR DESCRIPTION
Given the following code:

```php
function () {
    if (rand(0, 1)) {
        return true;
    }

    return false;
};
```

It currently remove space between `if` and `return false`:

```diff
There was 1 failure:

1) PhpParser\PrettyPrinterTest::testFormatPreservingPrint with data set "Users/samsonasik/www/PHP-Parser/test/code/formatPreservation/closure.test#0" ('Closure add static (/Users/sa....test)', '<?php\nfunction () {\n    if ...e;\n};', '$stmts[0]->expr->static = true;', '<?php\nstatic function () {\n...e;\n};', null)
Closure add static (/Users/samsonasik/www/PHP-Parser/test/code/formatPreservation/closure.test)
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
     if (rand(0, 1)) {
         return true;
     }
-
     return false;
```

when add `static`.