### PR TITLE
Skip incompatible armhf tests

### DIFF
--- a/test/PhpParser/CodeParsingTest.php
+++ b/test/PhpParser/CodeParsingTest.php
@@ -11,6 +11,10 @@ class CodeParsingTest extends CodeTestAbstract
      * @dataProvider provideTestParse
      */
     public function testParse($name, $code, $expected, $modeLine) {
+        if (strpos(php_uname('m'), 'arm') !== false and strpos($name, '/numberSeparators.test')) {
+            $this->markTestSkipped('Not armhf compatible. See GH#662 for further reference');
+        }
+
         if (null !== $modeLine) {
             $modes = array_fill_keys(explode(',', $modeLine), true);
         } else {

--- a/test/PhpParser/Lexer/EmulativeTest.php
+++ b/test/PhpParser/Lexer/EmulativeTest.php
@@ -109,6 +109,10 @@ class EmulativeTest extends LexerTest
      * @dataProvider provideTestLexNewFeatures
      */
     public function testLexNewFeatures($code, array $expectedTokens) {
+        if (strpos(php_uname('m'), 'arm') !== false and $code == '0xCAFE_F00D') {
+            $this->markTestSkipped('Not armhf compatible. See GH#662 for further reference');
+        }
+
         $lexer = $this->getLexer();
         $lexer->startLexing('<?php ' . $code);
         $this->assertSameTokens($expectedTokens, $lexer);


### PR DESCRIPTION
As pointed out in #662, there are a couple of tests failing for armhf.Possible alternatives to fix the issue include skipping the failing tests in arm or reducing the size of the integers being tested. This PR implements the former approach to kick-off discussions on the matter.

P.S.: I could not find a way of introducing an armhf CI here without providing a self hosted infrastructure.