### PR TITLE
Failing test case duplicated commented elseif on alternative syntax

### DIFF
--- a/test/code/prettyPrinter/comments.test
+++ b/test/code/prettyPrinter/comments.test
@@ -65,3 +65,39 @@ function test()
 {
     // empty
 }
+-----
+<div class="price-box">
+    <?php if (($_min = $this->getMinAmount()) && ($_max = $this->getMaxAmount()) && ($_min == $_max)): ?>
+        <span class="price" id="product-price-<?php echo $_id ?><?php echo $this->getIdSuffix() ?>">
+            <?php echo Mage::helper('core')->currency($_min, true, false) ?>
+        </span>
+    <?php elseif (($_min = $this->getMinAmount()) && $_min != 0): ?>
+        <span class="label"><?php echo Mage::helper('brainvire_giftcard')->__('From') ?></span>
+        <span class="price" id="min-product-price-<?php echo $_id ?><?php echo $this->getIdSuffix() ?>">
+            <?php echo Mage::helper('core')->currency($_min,true,false) ?>
+        </span>
+    <?php /*elseif ($_max = $this->getMaxAmount()): ?>
+        <span class="label"><?php echo Mage::helper('brainvire_giftcard')->__('Up To') ?></span>
+        <span class="price" id="max-product-price-<?php echo $_id ?><?php echo $this->getIdSuffix() ?>">
+            <?php echo Mage::helper('core')->currency($_max,true,false) ?>
+        </span>
+    <?php */endif; ?>
+</div>
+-----
+<div class="price-box">
+    <?php if (($_min = $this->getMinAmount()) && ($_max = $this->getMaxAmount()) && ($_min == $_max)): ?>
+        <span class="price" id="product-price-<?php echo $_id ?><?php echo $this->getIdSuffix() ?>">
+            <?php echo Mage::helper('core')->currency($_min, true, false) ?>
+        </span>
+    <?php elseif (($_min = $this->getMinAmount()) && $_min != 0): ?>
+        <span class="label"><?php echo Mage::helper('brainvire_giftcard')->__('From') ?></span>
+        <span class="price" id="min-product-price-<?php echo $_id ?><?php echo $this->getIdSuffix() ?>">
+            <?php echo Mage::helper('core')->currency($_min,true,false) ?>
+        </span>
+    <?php /*elseif ($_max = $this->getMaxAmount()): ?>
+        <span class="label"><?php echo Mage::helper('brainvire_giftcard')->__('Up To') ?></span>
+        <span class="price" id="max-product-price-<?php echo $_id ?><?php echo $this->getIdSuffix() ?>">
+            <?php echo Mage::helper('core')->currency($_max,true,false) ?>
+        </span>
+    <?php */endif; ?>
+</div>


### PR DESCRIPTION
This issue is discovered on Rector issue:

- https://github.com/rectorphp/rector/issues/7703

which only printing html+php with if in alternative syntax, it got duplicated commented code.

```diff
2) PhpParser\PrettyPrinterTest::testRoundTripPrint with data set "Users/samsonasik/www/PHP-Parser/test/code/prettyPrinter/comments.test#2" ('Comments (/Users/samsonasik/w....test)', '<div class="price-box">\n    ...</div>', '<div class="price-box">\n    ...</div>', null)
Comments (/Users/samsonasik/www/PHP-Parser/test/code/prettyPrinter/comments.test)
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
         <span class="price" id="max-product-price-<?php echo $_id ?><?php echo $this->getIdSuffix() ?>">
             <?php echo Mage::helper('core')->currency($_max,true,false) ?>
         </span>
+    <?php */<?php /*elseif ($_max = $this->getMaxAmount()): ?>
+        <span class="label"><?php echo Mage::helper('brainvire_giftcard')->__('Up To') ?></span>
+        <span class="price" id="max-product-price-<?php echo $_id ?><?php echo $this->getIdSuffix() ?>">
+            <?php echo Mage::helper('core')->currency($_max,true,false) ?>
+        </span>
     <?php */endif; ?>
```

Ref https://getrector.com/demo/06f6b4b3-883a-4f6d-9528-246001d66734
