### PR TITLE
[4.x] Add constructor property promotion

### DIFF
--- a/lib/PhpParser/Builder/Param.php
+++ b/lib/PhpParser/Builder/Param.php
@@ -19,6 +19,8 @@ class Param implements PhpParser\Builder
 
     protected $variadic = false;
 
+    protected $flags = 0;
+
     /** @var Node\AttributeGroup[] */
     protected $attributeGroups = [];
 
@@ -96,6 +98,39 @@ class Param implements PhpParser\Builder
     }
 
     /**
+     * Makes the parameter public.
+     *
+     * @return $this The builder instance (for fluid interface)
+     */
+    public function makePublic() {
+        $this->flags = BuilderHelpers::addModifier($this->flags, Node\Stmt\Class_::MODIFIER_PUBLIC);
+
+        return $this;
+    }
+
+    /**
+     * Makes the parameter protected.
+     *
+     * @return $this The builder instance (for fluid interface)
+     */
+    public function makeProtected() {
+        $this->flags = BuilderHelpers::addModifier($this->flags, Node\Stmt\Class_::MODIFIER_PROTECTED);
+
+        return $this;
+    }
+
+    /**
+     * Makes the parameter private.
+     *
+     * @return $this The builder instance (for fluid interface)
+     */
+    public function makePrivate() {
+        $this->flags = BuilderHelpers::addModifier($this->flags, Node\Stmt\Class_::MODIFIER_PRIVATE);
+
+        return $this;
+    }
+
+    /**
      * Adds an attribute group.
      *
      * @param Node\Attribute|Node\AttributeGroup $attribute
@@ -116,7 +151,7 @@ class Param implements PhpParser\Builder
     public function getNode() : Node {
         return new Node\Param(
             new Node\Expr\Variable($this->name),
-            $this->default, $this->type, $this->byRef, $this->variadic, [], 0, $this->attributeGroups
+            $this->default, $this->type, $this->byRef, $this->variadic, [], $this->flags, $this->attributeGroups
         );
     }
 }

--- a/test/PhpParser/Builder/ParamTest.php
+++ b/test/PhpParser/Builder/ParamTest.php
@@ -205,6 +205,42 @@ class ParamTest extends \PHPUnit\Framework\TestCase
         );
     }
 
+    public function testMakePublic() {
+        $node = $this->createParamBuilder('test')
+            ->makePublic()
+            ->getNode()
+        ;
+
+        $this->assertEquals(
+            new Node\Param(new Expr\Variable('test'), null, null, false, false, [], Node\Stmt\Class_::MODIFIER_PUBLIC),
+            $node
+        );
+    }
+
+    public function testMakeProtected() {
+        $node = $this->createParamBuilder('test')
+            ->makeProtected()
+            ->getNode()
+        ;
+
+        $this->assertEquals(
+            new Node\Param(new Expr\Variable('test'), null, null, false, false, [], Node\Stmt\Class_::MODIFIER_PROTECTED),
+            $node
+        );
+    }
+
+    public function testMakePrivate() {
+        $node = $this->createParamBuilder('test')
+            ->makePrivate()
+            ->getNode()
+        ;
+
+        $this->assertEquals(
+            new Node\Param(new Expr\Variable('test'), null, null, false, false, [], Node\Stmt\Class_::MODIFIER_PRIVATE),
+            $node
+        );
+    }
+
     public function testAddAttribute() {
         $attribute = new Attribute(
             new Name('Attr'),


### PR DESCRIPTION
By making flags on the Param builder configurable we can influence which are past to the Param node representation.