### PR TITLE
[5.x] Add constructor property promotion

### DIFF
--- a/lib/PhpParser/Builder/Param.php
+++ b/lib/PhpParser/Builder/Param.php
@@ -4,6 +4,7 @@ namespace PhpParser\Builder;
 
 use PhpParser;
 use PhpParser\BuilderHelpers;
+use PhpParser\Modifiers;
 use PhpParser\Node;
 
 class Param implements PhpParser\Builder {
@@ -15,6 +16,8 @@ class Param implements PhpParser\Builder {
     protected $type = null;
     /** @var bool */
     protected $byRef = false;
+    /** @var int */
+    protected $flags = 0;
     /** @var bool */
     protected $variadic = false;
     /** @var list<Node\AttributeGroup> */
@@ -81,6 +84,39 @@ class Param implements PhpParser\Builder {
     }
 
     /**
+     * Makes the parameter public.
+     *
+     * @return $this The builder instance (for fluid interface)
+     */
+    public function makePublic() {
+        $this->flags = BuilderHelpers::addModifier($this->flags, Modifiers::PUBLIC);
+
+        return $this;
+    }
+
+    /**
+     * Makes the parameter protected.
+     *
+     * @return $this The builder instance (for fluid interface)
+     */
+    public function makeProtected() {
+        $this->flags = BuilderHelpers::addModifier($this->flags, Modifiers::PROTECTED);
+
+        return $this;
+    }
+
+    /**
+     * Makes the parameter private.
+     *
+     * @return $this The builder instance (for fluid interface)
+     */
+    public function makePrivate() {
+        $this->flags = BuilderHelpers::addModifier($this->flags, Modifiers::PRIVATE);
+
+        return $this;
+    }
+
+    /**
      * Adds an attribute group.
      *
      * @param Node\Attribute|Node\AttributeGroup $attribute
@@ -101,7 +137,7 @@ class Param implements PhpParser\Builder {
     public function getNode(): Node {
         return new Node\Param(
             new Node\Expr\Variable($this->name),
-            $this->default, $this->type, $this->byRef, $this->variadic, [], 0, $this->attributeGroups
+            $this->default, $this->type, $this->byRef, $this->variadic, [], $this->flags, $this->attributeGroups
         );
     }
 }

--- a/test/PhpParser/Builder/ParamTest.php
+++ b/test/PhpParser/Builder/ParamTest.php
@@ -2,6 +2,7 @@
 
 namespace PhpParser\Builder;
 
+use PhpParser\Modifiers;
 use PhpParser\Node;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Attribute;
@@ -200,6 +201,42 @@ class ParamTest extends \PHPUnit\Framework\TestCase {
 
         $this->assertEquals(
             new Node\Param(new Expr\Variable('test'), null, null, false, true),
+            $node
+        );
+    }
+
+    public function testMakePublic() {
+        $node = $this->createParamBuilder('test')
+            ->makePublic()
+            ->getNode()
+        ;
+
+        $this->assertEquals(
+            new Node\Param(new Expr\Variable('test'), null, null, false, false, [], Modifiers::PUBLIC),
+            $node
+        );
+    }
+
+    public function testMakeProtected() {
+        $node = $this->createParamBuilder('test')
+            ->makeProtected()
+            ->getNode()
+        ;
+
+        $this->assertEquals(
+            new Node\Param(new Expr\Variable('test'), null, null, false, false, [], Modifiers::PROTECTED),
+            $node
+        );
+    }
+
+    public function testMakePrivate() {
+        $node = $this->createParamBuilder('test')
+            ->makePrivate()
+            ->getNode()
+        ;
+
+        $this->assertEquals(
+            new Node\Param(new Expr\Variable('test'), null, null, false, false, [], Modifiers::PRIVATE),
             $node
         );
     }


### PR DESCRIPTION
By making flags on the Param builder configurable we can influence which are past to the Param node representation.