### PR TITLE
Remove redundant parameter

### DIFF
--- a/lib/PhpParser/Parser/Php5.php
+++ b/lib/PhpParser/Parser/Php5.php
@@ -2627,7 +2627,7 @@ class Php5 extends \PhpParser\ParserAbstract
                  $this->semValue = new Expr\ArrayItem($this->semStack[$stackPos-(2-2)], null, true, $this->startAttributeStack[$stackPos-(2-1)] + $this->endAttributes);
             },
             552 => function ($stackPos) {
-                 $this->semValue = new Expr\ArrayItem($this->semStack[$stackPos-(2-2)], null, false, $this->startAttributeStack[$stackPos-(2-1)] + $this->endAttributes, true, $this->startAttributeStack[$stackPos-(2-1)] + $this->endAttributes);
+                 $this->semValue = new Expr\ArrayItem($this->semStack[$stackPos-(2-2)], null, false, $this->startAttributeStack[$stackPos-(2-1)] + $this->endAttributes, true);
             },
             553 => function ($stackPos) {
                  $this->semStack[$stackPos-(2-1)][] = $this->semStack[$stackPos-(2-2)]; $this->semValue = $this->semStack[$stackPos-(2-1)];

--- a/lib/PhpParser/Parser/Php7.php
+++ b/lib/PhpParser/Parser/Php7.php
@@ -2818,7 +2818,7 @@ class Php7 extends \PhpParser\ParserAbstract
                  $this->semValue = new Expr\ArrayItem($this->semStack[$stackPos-(3-3)], $this->semStack[$stackPos-(3-1)], false, $this->startAttributeStack[$stackPos-(3-1)] + $this->endAttributes);
             },
             592 => function ($stackPos) {
-                 $this->semValue = new Expr\ArrayItem($this->semStack[$stackPos-(2-2)], null, false, $this->startAttributeStack[$stackPos-(2-1)] + $this->endAttributes, true, $this->startAttributeStack[$stackPos-(2-1)] + $this->endAttributes);
+                 $this->semValue = new Expr\ArrayItem($this->semStack[$stackPos-(2-2)], null, false, $this->startAttributeStack[$stackPos-(2-1)] + $this->endAttributes, true);
             },
             593 => function ($stackPos) {
                  $this->semValue = null;


### PR DESCRIPTION
As the "__construct(Expr $value, Expr $key = null, bool $byRef = false, array $attributes = [], bool $unpack = false)" function (in ArrayItem.php) expects 1-5 parameters it would be better to remove redundant parameter in the Php7.php & Php5.php files to prevent possible issues in future.
These issues are found after PHP Stan checks.