### PR TITLE
Early return false after VariadicPlaceholder check on CallLike::isFirstClassCallable()

### DIFF
--- a/lib/PhpParser/Node/Expr/CallLike.php
+++ b/lib/PhpParser/Node/Expr/CallLike.php
@@ -19,15 +19,8 @@ abstract class CallLike extends Expr {
      * Returns whether this call expression is actually a first class callable.
      */
     public function isFirstClassCallable(): bool {
-        foreach ($this->getRawArgs() as $arg) {
-            if ($arg instanceof VariadicPlaceholder) {
-                return true;
-            }
-
-            return false;
-        }
-
-        return false;
+        $rawArgs = $this->getRawArgs();
+        return count($rawArgs) === 1 && current($rawArgs) instanceof VariadicPlaceholder;
     }
 
     /**

--- a/lib/PhpParser/Node/Expr/CallLike.php
+++ b/lib/PhpParser/Node/Expr/CallLike.php
@@ -23,7 +23,10 @@ abstract class CallLike extends Expr {
             if ($arg instanceof VariadicPlaceholder) {
                 return true;
             }
+
+            return false;
         }
+
         return false;
     }
 


### PR DESCRIPTION
If I understand correctly, `VariadicPlaceholder` will only exists on first arg, after it, it will always an Arg. so no need whole loop to verify another `VariadicPlaceholder`, this can speed up usage on `getArgs()` method as assert check.