### PR TITLE
Update main.yml to use GitHub Actions V3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
     name: "PHP 7.0 Unit Tests"
     steps:
       - name: "Checkout"
-        uses: "actions/checkout@v2"
+        uses: "actions/checkout@v3"
       - name: "Install PHP"
         uses: "shivammathur/setup-php@v2"
         with:
@@ -43,7 +43,7 @@ jobs:
           - "8.2"
     steps:
       - name: "Checkout"
-        uses: "actions/checkout@v2"
+        uses: "actions/checkout@v3"
       - name: "Install PHP"
         uses: "shivammathur/setup-php@v2"
         with:
@@ -59,7 +59,7 @@ jobs:
     name: "PHP 7.3 Code on PHP 8.0 Integration Tests"
     steps:
       - name: "Checkout"
-        uses: "actions/checkout@v2"
+        uses: "actions/checkout@v3"
       - name: "Install PHP"
         uses: "shivammathur/setup-php@v2"
         with:
@@ -75,7 +75,7 @@ jobs:
     name: "PHP 8.1 Code on PHP 7.0 Integration Tests"
     steps:
       - name: "Checkout"
-        uses: "actions/checkout@v2"
+        uses: "actions/checkout@v3"
       - name: "Install PHP"
         uses: "shivammathur/setup-php@v2"
         with:


### PR DESCRIPTION
Updates the GitHub Actions from V2 (Deprecated) to V3 (using Node16 instead of Node12)

This will resolve the warning show at https://github.com/nikic/PHP-Parser/actions/runs/5106129693

## Additional context
-  https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/