### PR TITLE
Option to keep redundant parentheses

### DIFF
--- a/grammar/php.y
+++ b/grammar/php.y
@@ -1021,7 +1021,7 @@ expr:
     | expr '>' expr                                         { $$ = Expr\BinaryOp\Greater       [$1, $3]; }
     | expr T_IS_GREATER_OR_EQUAL expr                       { $$ = Expr\BinaryOp\GreaterOrEqual[$1, $3]; }
     | expr T_INSTANCEOF class_name_reference                { $$ = Expr\Instanceof_[$1, $3]; }
-    | '(' expr ')'                                          { $$ = $2; }
+    | '(' expr ')'                                          { $$ = $this->keepRedundantParentheses ? Expr\Parenthesized[$2] : $2; }
     | expr '?' expr ':' expr                                { $$ = Expr\Ternary[$1, $3,   $5]; }
     | expr '?' ':' expr                                     { $$ = Expr\Ternary[$1, null, $4]; }
     | expr T_COALESCE expr                                  { $$ = Expr\BinaryOp\Coalesce[$1, $3]; }

--- a/lib/PhpParser/Node/Expr/Parenthesized.php
+++ b/lib/PhpParser/Node/Expr/Parenthesized.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types=1);
+
+namespace PhpParser\Node\Expr;
+
+use PhpParser\Node\Expr;
+
+class Parenthesized extends Expr
+{
+    /** @var Expr $expr */
+    public $expr;
+
+    /**
+     * Constructs a parenthesized expression.
+     *
+     * @param Expr $expr  Expression to be parenthesized
+     * @param array       $attributes Additional attributes
+     */
+    public function __construct(Expr $expr, array $attributes = []) {
+        $this->attributes = $attributes;
+        $this->expr = $expr;
+    }
+
+    public function getSubNodeNames() : array {
+        return ['expr'];
+    }
+    
+    public function getType() : string {
+        return 'Expr_Parenthesized';
+    }
+}

--- a/lib/PhpParser/Parser/Php7.php
+++ b/lib/PhpParser/Parser/Php7.php
@@ -2266,7 +2266,7 @@ class Php7 extends \PhpParser\ParserAbstract
                  $this->semValue = new Expr\Instanceof_($this->semStack[$stackPos-(3-1)], $this->semStack[$stackPos-(3-3)], $this->startAttributeStack[$stackPos-(3-1)] + $this->endAttributes);
             },
             446 => function ($stackPos) {
-                 $this->semValue = $this->semStack[$stackPos-(3-2)];
+                 $this->semValue = $this->keepRedundantParentheses ? new Expr\Parenthesized($this->semStack[$stackPos-(3-2)], $this->startAttributeStack[$stackPos-(3-1)] + $this->endAttributes) : $this->semStack[$stackPos-(3-2)];
             },
             447 => function ($stackPos) {
                  $this->semValue = new Expr\Ternary($this->semStack[$stackPos-(5-1)], $this->semStack[$stackPos-(5-3)], $this->semStack[$stackPos-(5-5)], $this->startAttributeStack[$stackPos-(5-1)] + $this->endAttributes);

--- a/lib/PhpParser/Parser/Php8.php
+++ b/lib/PhpParser/Parser/Php8.php
@@ -2274,7 +2274,7 @@ class Php8 extends \PhpParser\ParserAbstract
                  $this->semValue = new Expr\Instanceof_($this->semStack[$stackPos-(3-1)], $this->semStack[$stackPos-(3-3)], $this->startAttributeStack[$stackPos-(3-1)] + $this->endAttributes);
             },
             446 => function ($stackPos) {
-                 $this->semValue = $this->semStack[$stackPos-(3-2)];
+                 $this->semValue = $this->keepRedundantParentheses ? new Expr\Parenthesized($this->semStack[$stackPos-(3-2)], $this->startAttributeStack[$stackPos-(3-1)] + $this->endAttributes) : $this->semStack[$stackPos-(3-2)];
             },
             447 => function ($stackPos) {
                  $this->semValue = new Expr\Ternary($this->semStack[$stackPos-(5-1)], $this->semStack[$stackPos-(5-3)], $this->semStack[$stackPos-(5-5)], $this->startAttributeStack[$stackPos-(5-1)] + $this->endAttributes);

--- a/lib/PhpParser/ParserAbstract.php
+++ b/lib/PhpParser/ParserAbstract.php
@@ -38,6 +38,8 @@ abstract class ParserAbstract implements Parser {
     protected $lexer;
     /** @var PhpVersion PHP version to target on a best-effort basis */
     protected $phpVersion;
+    /** @var bool whether or not redundant parentheses are kept */
+    protected $keepRedundantParentheses = false;
 
     /*
      * The following members will be filled with generated parsing data:
@@ -148,9 +150,10 @@ abstract class ParserAbstract implements Parser {
      *        errors in older versions and interpreting type hints as a name or identifier depending
      *        on version.
      */
-    public function __construct(Lexer $lexer, ?PhpVersion $phpVersion = null) {
+    public function __construct(Lexer $lexer, ?PhpVersion $phpVersion = null, array $parserOptions = []) {
         $this->lexer = $lexer;
         $this->phpVersion = $phpVersion ?? PhpVersion::getNewestSupported();
+        $this->keepRedundantParentheses = !empty($parserOptions['keepRedundantParentheses']);
 
         $this->initReduceCallbacks();
         $this->phpTokenToSymbol = $this->createTokenMap();

--- a/lib/PhpParser/ParserFactory.php
+++ b/lib/PhpParser/ParserFactory.php
@@ -19,14 +19,14 @@ class ParserFactory {
      *
      * @deprecated Use createForVersion(), createForNewestSupportedVersion() or createForHostVersion() instead.
      */
-    public function create(int $kind, ?Lexer $lexer = null): Parser {
+    public function create(int $kind, ?Lexer $lexer = null, $parserOptions = []): Parser {
         if (null === $lexer) {
             $lexer = new Lexer\Emulative();
         }
         switch ($kind) {
             case self::PREFER_PHP7:
             case self::ONLY_PHP7:
-                return new Parser\Php7($lexer);
+                return new Parser\Php7($lexer, null, $parserOptions);
             default:
                 throw new \LogicException(
                     'Kind must be one of ::PREFER_PHP7 or ::ONLY_PHP7'
@@ -41,16 +41,16 @@ class ParserFactory {
      *
      * @param array<string, mixed> $lexerOptions Lexer options
      */
-    public function createForVersion(PhpVersion $version, array $lexerOptions = []): Parser {
+    public function createForVersion(PhpVersion $version, array $lexerOptions = [], array $parserOptions = []): Parser {
         if ($version->isHostVersion()) {
             $lexer = new Lexer($lexerOptions);
         } else {
             $lexer = new Lexer\Emulative($lexerOptions + ['phpVersion' => $version]);
         }
         if ($version->id >= 80000) {
-            return new Php8($lexer, $version);
+            return new Php8($lexer, $version, $parserOptions);
         }
-        return new Php7($lexer, $version);
+        return new Php7($lexer, $version, $parserOptions);
     }
 
     /**
@@ -60,8 +60,8 @@ class ParserFactory {
      *
      * @param array<string, mixed> $lexerOptions Lexer options
      */
-    public function createForNewestSupportedVersion(array $lexerOptions = []): Parser {
-        return $this->createForVersion(PhpVersion::getNewestSupported(), $lexerOptions);
+    public function createForNewestSupportedVersion(array $lexerOptions = [], array $parserOptions = []): Parser {
+        return $this->createForVersion(PhpVersion::getNewestSupported(), $lexerOptions, $parserOptions);
     }
 
     /**
@@ -70,7 +70,7 @@ class ParserFactory {
      *
      * @param array<string, mixed> $lexerOptions Lexer options
      */
-    public function createForHostVersion(array $lexerOptions = []): Parser {
-        return $this->createForVersion(PhpVersion::getHostVersion(), $lexerOptions);
+    public function createForHostVersion(array $lexerOptions = [], array $parserOptions = []): Parser {
+        return $this->createForVersion(PhpVersion::getHostVersion(), $lexerOptions, $parserOptions);
     }
 }

--- a/lib/PhpParser/PrettyPrinter/Standard.php
+++ b/lib/PhpParser/PrettyPrinter/Standard.php
@@ -732,6 +732,10 @@ class Standard extends PrettyPrinterAbstract {
         }
     }
 
+    protected function pExpr_Parenthesized(Expr\Parenthesized $node): string {
+        return '(' . $this->p($node->expr) . ')';
+    }
+
     // Declarations
 
     protected function pStmt_Namespace(Stmt\Namespace_ $node): string {

--- a/test/PhpParser/CodeParsingTest.php
+++ b/test/PhpParser/CodeParsingTest.php
@@ -11,14 +11,18 @@ class CodeParsingTest extends CodeTestAbstract {
      */
     public function testParse($name, $code, $expected, $modeLine) {
         $modes = $this->parseModeLine($modeLine);
-        $parser = $this->createParser($modes['version'] ?? null);
+        $parserOptions = [];
+        if (!empty($modes['keepRedundantParentheses'])) {
+            $parserOptions['keepRedundantParentheses'] = true;
+        }
+        $parser = $this->createParser($modes['version'] ?? null, $parserOptions);
         list($stmts, $output) = $this->getParseOutput($parser, $code, $modes);
 
         $this->assertSame($expected, $output, $name);
         $this->checkAttributes($stmts);
     }
 
-    public function createParser(?string $version): Parser {
+    public function createParser(?string $version, $parserOptions = []): Parser {
         $factory = new ParserFactory();
         $version = $version === null
             ? PhpVersion::getNewestSupported() : PhpVersion::fromString($version);
@@ -29,7 +33,7 @@ class CodeParsingTest extends CodeTestAbstract {
                 'startFilePos', 'endFilePos',
                 'startTokenPos', 'endTokenPos',
                 'comments'
-            ]]);
+            ]], $parserOptions);
     }
 
     // Must be public for updateTests.php

--- a/test/code/parser/keepRedundantParentheses.test
+++ b/test/code/parser/keepRedundantParentheses.test
@@ -1,0 +1,128 @@
+Redundant parentheses
+-----
+<?php
+
+1 * (2 + 3);
+-----
+!!keepRedundantParentheses
+array(
+    0: Stmt_Expression(
+        expr: Expr_BinaryOp_Mul(
+            left: Scalar_Int(
+                value: 1
+            )
+            right: Expr_Parenthesized(
+                expr: Expr_BinaryOp_Plus(
+                    left: Scalar_Int(
+                        value: 2
+                    )
+                    right: Scalar_Int(
+                        value: 3
+                    )
+                )
+            )
+        )
+    )
+)
+-----
+<?php
+
+1 * (2 + 3);
+-----
+array(
+    0: Stmt_Expression(
+        expr: Expr_BinaryOp_Mul(
+            left: Scalar_Int(
+                value: 1
+            )
+            right: Expr_BinaryOp_Plus(
+                left: Scalar_Int(
+                    value: 2
+                )
+                right: Scalar_Int(
+                    value: 3
+                )
+            )
+        )
+    )
+)
+-----
+<?php
+
+(1 * 2) + 3;
+-----
+!!keepRedundantParentheses
+array(
+    0: Stmt_Expression(
+        expr: Expr_BinaryOp_Plus(
+            left: Expr_Parenthesized(
+                expr: Expr_BinaryOp_Mul(
+                    left: Scalar_Int(
+                        value: 1
+                    )
+                    right: Scalar_Int(
+                        value: 2
+                    )
+                )
+            )
+            right: Scalar_Int(
+                value: 3
+            )
+        )
+    )
+)
+-----
+<?php
+
+(1 * 2) + 3;
+-----
+array(
+    0: Stmt_Expression(
+        expr: Expr_BinaryOp_Plus(
+            left: Expr_BinaryOp_Mul(
+                left: Scalar_Int(
+                    value: 1
+                )
+                right: Scalar_Int(
+                    value: 2
+                )
+            )
+            right: Scalar_Int(
+                value: 3
+            )
+        )
+    )
+)
+-----
+<?php
+
+include("test.php");
+-----
+!!keepRedundantParentheses
+array(
+    0: Stmt_Expression(
+        expr: Expr_Include(
+            expr: Expr_Parenthesized(
+                expr: Scalar_String(
+                    value: test.php
+                )
+            )
+            type: TYPE_INCLUDE (1)
+        )
+    )
+)
+-----
+<?php
+
+include("test.php");
+-----
+array(
+    0: Stmt_Expression(
+        expr: Expr_Include(
+            expr: Scalar_String(
+                value: test.php
+            )
+            type: TYPE_INCLUDE (1)
+        )
+    )
+)


### PR DESCRIPTION
I know this goes against a true AST, but could there be an option to keep redundant parentheses?

Something similar to https://clang.llvm.org/doxygen/classclang_1_1ParenExpr.html#details