### PR TITLE
PrettyPrinter indentation incorrect for Heredoc and Nowdoc

### DIFF
--- a/test/PhpParser/PrettyPrinterTest.php
+++ b/test/PhpParser/PrettyPrinterTest.php
@@ -304,4 +304,51 @@ CODE
             $this->getTests(__DIR__ . '/../code/parser', 'test')
         );
     }
+
+    public function testNowdocIndentation() {
+        $source = <<<'SOURCE'
+        <?php
+        function foo()
+        {
+            if (bar()) {
+                $nowdoc = <<<'NOWDOC'
+                    indented text
+                            more indented text
+                        less indented text
+                NOWDOC;
+            }
+        }
+        SOURCE;
+
+        $parserFactory = new ParserFactory();
+        $parser = $parserFactory->create(ParserFactory::PREFER_PHP7);
+        $nodes = $parser->parse($source);
+        $printer = new PrettyPrinter\Standard();
+        $actual = $printer->prettyPrintFile($nodes);
+        $this->assertSame($source, $actual);
+    }
+
+
+    public function testHeredocIndentation() {
+        $source = <<<'SOURCE'
+        <?php
+        function foo()
+        {
+            if (bar()) {
+                $heredoc = <<<HEREDOC
+                    indented text
+                            more indented text
+                        less indented text
+                HEREDOC;
+            }
+        }
+        SOURCE;
+
+        $parserFactory = new ParserFactory();
+        $parser = $parserFactory->create(ParserFactory::PREFER_PHP7);
+        $nodes = $parser->parse($source);
+        $printer = new PrettyPrinter\Standard();
+        $actual = $printer->prettyPrintFile($nodes);
+        $this->assertSame($source, $actual);
+    }
 }


### PR DESCRIPTION
It appears the pretty-printer does not add the initial indentation to each line of heredoc and nowdoc bodies, causing syntax errors in the pretty-printed code. This PR shows the issue as a pair of failing unit tests.

The solution is to replace each EOL character in the body with EOL+indent, but I am not sure how to pull that off with the included pretty-printer. (The PHP-Styler solutions are [here](https://github.com/pmjones/php-styler/commit/919c068a3ce006266b50289d7b5f7662cd1238bf#diff-3f863aeebf570e8ea21e744df5a21ab2a17369cd3d2bf8bd65f65a1e5ec65264) and [here](https://github.com/pmjones/php-styler/commit/b4a48304897f95fb02901adf7a4aaecb10f54706#diff-3f863aeebf570e8ea21e744df5a21ab2a17369cd3d2bf8bd65f65a1e5ec65264R761) but may not be useful to PHP-Parser.)