### PR TITLE
Fix missing type annotations in AST nodes

### DIFF
--- a/lib/PhpParser/Node/Expr/ArrowFunction.php
+++ b/lib/PhpParser/Node/Expr/ArrowFunction.php
@@ -7,8 +7,10 @@ use PhpParser\Node\Expr;
 use PhpParser\Node\FunctionLike;
 
 class ArrowFunction extends Expr implements FunctionLike {
+    /** @var bool Whether the closure is static */
     public bool $static;
 
+    /** @var bool Whether to return by reference */
     public bool $byRef;
 
     /** @var Node\Param[] */
@@ -17,6 +19,7 @@ class ArrowFunction extends Expr implements FunctionLike {
     /** @var null|Node\Identifier|Node\Name|Node\ComplexType */
     public ?Node $returnType;
 
+    /** @var Expr Expression body */
     public Expr $expr;
     /** @var Node\AttributeGroup[] */
     public array $attrGroups;

--- a/lib/PhpParser/Node/Expr/Match_.php
+++ b/lib/PhpParser/Node/Expr/Match_.php
@@ -6,12 +6,15 @@ use PhpParser\Node;
 use PhpParser\Node\MatchArm;
 
 class Match_ extends Node\Expr {
+    /** @var Node\Expr Condition */
     public Node\Expr $cond;
     /** @var MatchArm[] */
     public array $arms;
 
     /**
+     * @param Node\Expr $cond Condition
      * @param MatchArm[] $arms
+     * @param array<string, mixed> $attributes Additional attributes
      */
     public function __construct(Node\Expr $cond, array $arms = [], array $attributes = []) {
         $this->attributes = $attributes;

--- a/lib/PhpParser/Node/Param.php
+++ b/lib/PhpParser/Node/Param.php
@@ -17,6 +17,7 @@ class Param extends NodeAbstract {
     public Expr $var;
     /** @var null|Expr Default value */
     public ?Expr $default;
+    /** @var int Optional visibility flags */
     public int $flags;
     /** @var AttributeGroup[] PHP attribute groups */
     public array $attrGroups;


### PR DESCRIPTION
# Description

After upgrading to v5.0.0, there were some missing type annotations in the AST nodes class which those types were correctly annotated in v4.x

# What does this PR do

Add the missing types

# Why did we find this issue? 

I am working on a project that generates TypeScript type definition files for the PHP Parser dumped AST nodes(by `-j` option of the  CLI command). those types should be generated automatically through the PHP source code, it depends on the type annotation to infer the proper TS types. 

It works very well for v4. today, I tried to migrate it to v5. and when I rerun the `generate` script. I found the missing types. 