### PR TITLE
Improve performance of find() and findFirst() when passed $nodes is empty array

### DIFF
--- a/lib/PhpParser/NodeFinder.php
+++ b/lib/PhpParser/NodeFinder.php
@@ -15,6 +15,10 @@ class NodeFinder {
      * @return Node[] Found nodes satisfying the filter callback
      */
     public function find($nodes, callable $filter): array {
+        if ($nodes === []) {
+            return [];
+        }
+
         if (!is_array($nodes)) {
             $nodes = [$nodes];
         }
@@ -52,6 +56,10 @@ class NodeFinder {
      * @return null|Node Found node (or null if none found)
      */
     public function findFirst($nodes, callable $filter): ?Node {
+        if ($nodes === []) {
+            return null;
+        }
+
         if (!is_array($nodes)) {
             $nodes = [$nodes];
         }


### PR DESCRIPTION
No need to create `FindingVisitor` and `NodeTraverser` next when passed `$nodes` is empty array.