### PR TITLE
build: Exclude grammar from export git artifact

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,6 @@
 /.github         export-ignore
 /doc             export-ignore
+/grammar         export-ignore
 /test            export-ignore
 /test_old        export-ignore
 .editorconfig    export-ignore


### PR DESCRIPTION
Closes #957.