### PR TITLE
Given that the solitary element includes a newline, we categorize it …

### DIFF
--- a/lib/PhpParser/PrettyPrinterAbstract.php
+++ b/lib/PhpParser/PrettyPrinterAbstract.php
@@ -6,6 +6,7 @@ use PhpParser\Internal\DiffElem;
 use PhpParser\Internal\Differ;
 use PhpParser\Internal\PrintableNewAnonClassNode;
 use PhpParser\Internal\TokenStream;
+use PhpParser\Node\ArrayItem;
 use PhpParser\Node\AttributeGroup;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\AssignOp;
@@ -1211,8 +1212,20 @@ abstract class PrettyPrinterAbstract implements PrettyPrinter {
      * @return bool Whether multiline formatting is used
      */
     protected function isMultiline(array $nodes): bool {
-        if (\count($nodes) < 2) {
+        if (!$nodes) {
             return false;
+        }
+
+        if (count($nodes) === 1) {
+            $node = current($nodes);
+            $startPos = $node->getStartTokenPos() - 1;
+            $endPos = $node->getEndTokenPos() + 1;
+            $text = $this->origTokens->getTokenCode($startPos, $endPos, 0);
+            if (false === strpos($text, "\n")) {
+                return false;
+            }
+
+            return true; // Since the only element has a new line, we consider it multiline
         }
 
         $pos = -1;

--- a/test/code/formatPreservation/array_spread.test
+++ b/test/code/formatPreservation/array_spread.test
@@ -10,7 +10,8 @@ $array->items[] = new Expr\ArrayItem(new Expr\Variable('b'));
 -----
 <?php
 $items = [
-...$value, $b
+...$value,
+$b
 ];
 -----
 <?php
@@ -25,5 +26,6 @@ $array->items[] = new Expr\ArrayItem(new Expr\Variable('c'), null, false, [], tr
 <?php
 $items =
 [
-... $value, ...$c
+... $value,
+...$c
 ];

--- a/test/code/formatPreservation/arrow_function.test
+++ b/test/code/formatPreservation/arrow_function.test
@@ -21,7 +21,8 @@ $stmts[0]->expr->params[] = new Node\Param(new Expr\Variable('b'));
 -----
 <?php
 fn(
-$a, $b
+$a,
+$b
 ) => $a;
 -----
 <?php


### PR DESCRIPTION
[IMPROVEMENT] When there is a single element in the array with a new line, consider it as multiline.