### PR TITLE
Add dev tool files to export-ignore

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,7 +7,11 @@
 .editorconfig    export-ignore
 .gitattributes   export-ignore
 .gitignore       export-ignore
+.php-cs-fixer.dist.php  export-ignore
+Makefile         export-ignore
 CHANGELOG.md     export-ignore
 CONTRIBUTING.md  export-ignore
+phpstan-baseline.neon   export-ignore
+phpstan.neon.dist   export-ignore
 phpunit.xml.dist export-ignore
 UPGRADE-*.md     export-ignore


### PR DESCRIPTION
If you need indentation to align `export-ignore` in the same position, please let me know.