### PR TITLE
Prevent off-by-one errors in line-number related methods

### DIFF
--- a/lib/PhpParser/Comment.php
+++ b/lib/PhpParser/Comment.php
@@ -46,6 +46,7 @@ class Comment implements \JsonSerializable {
      * Gets the line number the comment started on.
      *
      * @return int Line number (or -1 if not available)
+     * @phpstan-return -1|positive-int
      */
     public function getStartLine(): int {
         return $this->startLine;
@@ -73,6 +74,7 @@ class Comment implements \JsonSerializable {
      * Gets the line number the comment ends on.
      *
      * @return int Line number (or -1 if not available)
+     * @phpstan-return -1|positive-int
      */
     public function getEndLine(): int {
         return $this->endLine;

--- a/lib/PhpParser/Error.php
+++ b/lib/PhpParser/Error.php
@@ -32,6 +32,7 @@ class Error extends \RuntimeException {
      * Gets the line the error starts in.
      *
      * @return int Error start line
+     * @phpstan-return -1|positive-int
      */
     public function getStartLine(): int {
         return $this->attributes['startLine'] ?? -1;
@@ -41,6 +42,7 @@ class Error extends \RuntimeException {
      * Gets the line the error ends in.
      *
      * @return int Error end line
+     * @phpstan-return -1|positive-int
      */
     public function getEndLine(): int {
         return $this->attributes['endLine'] ?? -1;

--- a/lib/PhpParser/Node.php
+++ b/lib/PhpParser/Node.php
@@ -21,6 +21,7 @@ interface Node {
      * Gets line the node started in (alias of getStartLine).
      *
      * @return int Start line (or -1 if not available)
+     * @phpstan-return -1|positive-int
      *
      * @deprecated Use getStartLine() instead
      */
@@ -32,6 +33,7 @@ interface Node {
      * Requires the 'startLine' attribute to be enabled in the lexer (enabled by default).
      *
      * @return int Start line (or -1 if not available)
+     * @phpstan-return -1|positive-int
      */
     public function getStartLine(): int;
 
@@ -41,6 +43,7 @@ interface Node {
      * Requires the 'endLine' attribute to be enabled in the lexer (enabled by default).
      *
      * @return int End line (or -1 if not available)
+     * @phpstan-return -1|positive-int
      */
     public function getEndLine(): int;
 

--- a/lib/PhpParser/NodeAbstract.php
+++ b/lib/PhpParser/NodeAbstract.php
@@ -19,6 +19,7 @@ abstract class NodeAbstract implements Node, \JsonSerializable {
      * Gets line the node started in (alias of getStartLine).
      *
      * @return int Start line (or -1 if not available)
+     * @phpstan-return -1|positive-int
      */
     public function getLine(): int {
         return $this->attributes['startLine'] ?? -1;
@@ -30,6 +31,7 @@ abstract class NodeAbstract implements Node, \JsonSerializable {
      * Requires the 'startLine' attribute to be enabled in the lexer (enabled by default).
      *
      * @return int Start line (or -1 if not available)
+     * @phpstan-return -1|positive-int
      */
     public function getStartLine(): int {
         return $this->attributes['startLine'] ?? -1;
@@ -41,6 +43,7 @@ abstract class NodeAbstract implements Node, \JsonSerializable {
      * Requires the 'endLine' attribute to be enabled in the lexer (enabled by default).
      *
      * @return int End line (or -1 if not available)
+     * @phpstan-return -1|positive-int
      */
     public function getEndLine(): int {
         return $this->attributes['endLine'] ?? -1;


### PR DESCRIPTION
when working with line numbers, one could easily do off-by-one errors because of assumptions about whether line numbers start at `0` or `1`.

the added phpdocs make sure that static analysis, no matter whether phpstan or psalm, can detect errors like that. psalm will also work with these `phpstan`-prefixed phpdocs.