### PR TITLE
Add getTypeNode and toString to Param for getting more infos

### DIFF
--- a/lib/PhpParser/Node/Param.php
+++ b/lib/PhpParser/Node/Param.php
@@ -60,6 +60,13 @@ class Param extends NodeAbstract {
     }
 
     /**
+     * @return null|Identifier|Name|ComplexType
+     */
+    public function getTypeNode(): ?Node {
+        return $this->type;
+    }
+
+    /**
      * Whether this parameter uses constructor property promotion.
      */
     public function isPromoted(): bool {

--- a/lib/PhpParser/Node/Param.php
+++ b/lib/PhpParser/Node/Param.php
@@ -66,6 +66,10 @@ class Param extends NodeAbstract {
         return $this->type;
     }
 
+    public function toString(): string {
+        return $this->var->name;
+    }
+
     /**
      * Whether this parameter uses constructor property promotion.
      */

--- a/test/PhpParser/Node/ParamTest.php
+++ b/test/PhpParser/Node/ParamTest.php
@@ -39,4 +39,9 @@ class ParamTest extends \PHPUnit\Framework\TestCase {
         $node = new Param(new Variable('foo'), null, new Name('FooInterface'));
         $this->assertEquals('FooInterface', $node->getTypeNode()->toString());
     }
+
+    public function testToString() {
+        $node = new Param(new Variable('foo'));
+        $this->assertEquals('foo', $node->toString());
+    }
 }

--- a/test/PhpParser/Node/ParamTest.php
+++ b/test/PhpParser/Node/ParamTest.php
@@ -34,4 +34,9 @@ class ParamTest extends \PHPUnit\Framework\TestCase {
             ['readonly'],
         ];
     }
+
+    public function testGetTypeNode() {
+        $node = new Param(new Variable('foo'), null, new Name('FooInterface'));
+        $this->assertEquals('FooInterface', $node->getTypeNode()->toString());
+    }
 }


### PR DESCRIPTION
At the moment, it is not possible to have access to type and name information of a function parameter, because `Node\Param` give no access to read the `$type` or `$var` property. `getType` will just return the string `Param`. So I added a simple getter `getTypeNode` to provide type infos and `toString` to get the name of the parameter (Same pattern like in function).

This PR shouldn't have any BC breaks.