### PR TITLE
Fix a typo: `Dereferenceing` to `Dereferencing`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ Version 5.1.0-dev
 
 ### Added
 
-* [8.4] Added support for dereferenceing `new` expressions without parentheses.
+* [8.4] Added support for dereferencing `new` expressions without parentheses.
 
 Version 5.0.2 (2024-03-05)
 --------------------------


### PR DESCRIPTION
# What's this PR for

Fix a tiny typo

`Dereferenceing` to `Dereferencing`

it is also for being consistent with other parts of the codebase: https://github.com/search?q=repo%3Anikic%2FPHP-Parser%20dereferencing&type=code