### PR TITLE
Fix the invalid JSON structure

### DIFF
--- a/doc/component/JSON_representation.markdown
+++ b/doc/component/JSON_representation.markdown
@@ -104,7 +104,7 @@ This will result in the following output (which includes attributes):
                         "nodeType": "Scalar_String",
                         "attributes": {
                             "startLine": 5,
-                            "endLine": 5
+                            "endLine": 5,
                             "kind": 2,
                             "rawValue": "\"\\n\""
                         },


### PR DESCRIPTION
I was converting the structure into Go, and saw that a very minor issue exists with the JSON example.