### PR TITLE
Weird token issue reproduction

### DIFF
--- a/test/PhpParser/WeirdTokenIssueTest.php
+++ b/test/PhpParser/WeirdTokenIssueTest.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types=1);
+
+namespace PhpParser;
+
+use PHPUnit\Framework\TestCase;
+use function file_get_contents;
+
+class WeirdTokenIssueTest extends TestCase
+{
+	public function testIssue(): void
+	{
+		$factory = new ParserFactory();
+		$parser = $factory->createForNewestSupportedVersion();
+		$parser->parse(file_get_contents(__DIR__ . '/ignore-line-1.php'));
+
+		$tokens = $parser->getTokens();
+		$lastToken = $tokens[count($tokens) - 1];
+		var_dump(ord($lastToken->text));
+		var_dump(bin2hex($lastToken->text));
+		var_dump(strlen($lastToken->text));
+	}
+}

--- a/test/PhpParser/WeirdTokenIssueTest.php
+++ b/test/PhpParser/WeirdTokenIssueTest.php
@@ -14,9 +14,27 @@ class WeirdTokenIssueTest extends TestCase
 		$parser->parse(file_get_contents(__DIR__ . '/ignore-line-1.php'));
 
 		$tokens = $parser->getTokens();
-		$lastToken = $tokens[count($tokens) - 1];
-		var_dump(ord($lastToken->text));
-		var_dump(bin2hex($lastToken->text));
-		var_dump(strlen($lastToken->text));
+		$newContent = '';
+		foreach ($tokens as $token) {
+			$newContent .= $token->text;
+		}
+
+		$this->assertStringEqualsFile(__DIR__ . '/ignore-line-1.php', $newContent);
+	}
+
+	public function testUnsetLastToken(): void
+	{
+		$factory = new ParserFactory();
+		$parser = $factory->createForNewestSupportedVersion();
+		$parser->parse(file_get_contents(__DIR__ . '/ignore-line-1.php'));
+
+		$tokens = $parser->getTokens();
+		unset($tokens[count($tokens) - 1]);
+		$newContent = '';
+		foreach ($tokens as $token) {
+			$newContent .= $token->text;
+		}
+
+		$this->assertStringEqualsFile(__DIR__ . '/ignore-line-1.php', $newContent);
 	}
 }

--- a/test/PhpParser/ignore-line-1.php
+++ b/test/PhpParser/ignore-line-1.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace PhpParser;
+
+class Foo
+{
+
+	public function doFoo(): void
+	{
+		echo []; // @phpstan-ignore-line
+
+		// @phpstan-ignore-next-line
+		echo [];
+
+		echo []; /* @phpstan-ignore-line */
+
+		/* @phpstan-ignore-next-line */
+		echo [];
+
+		echo []; /** @phpstan-ignore-line */
+
+		/** @phpstan-ignore-next-line */
+		echo [];
+
+		$this->multiCall(
+			1,
+			2, // @phpstan-ignore-next-line
+			3
+		);
+
+		/**
+		 * @phpstan-ignore-next-line
+		 */
+		echo [];
+
+		/** @phpstan-ignore-next-line why we do this */
+		echo [];
+
+		$this->multiCall(
+			1,
+			2, // @phpstan-ignore-next-line why we do this
+			3
+		);
+
+		/**
+		 * @phpstan-ignore-next-line
+		 * hahaha
+		 */
+		echo [];
+
+		$this->multiCall(
+			1,
+			2, /* @phpstan-ignore-next-line */
+			3
+		);
+
+		$this->multiCall(
+			1,
+			2, // @phpstan-ignore-next-line
+			3 // something something
+		);
+
+		/** @phpstan-ignore-next-line */
+		echo [];
+
+		/** @phpstan-ignore-next-line */
+		echo [];
+	}
+
+}


### PR DESCRIPTION
Hi,
I'm getting a weird character at the end of tokens array with PHP-Parser 5.x.

This is how it looks like in Xdebug:

![Screenshot 2024-09-04 at 23 34 10](https://github.com/user-attachments/assets/03e592f8-e1ee-4209-90d1-238d1e46de08)

When I'm trying to dump it:

```php
		var_dump(ord($lastToken->text));
		var_dump(bin2hex($lastToken->text));
		var_dump(strlen($lastToken->text));
```

The output looks like this:

```
int(0)
string(2) "00"
int(1)
```

Which is the same as empty string (https://3v4l.org/60Utu) except for the length.

I'm attaching a test case that shows this behaviour.

When I run the equivalent test case on PHP-Parser 4.x, the printed character is LF (newline) which is expected. But not on master (5.x).

Any help is appreciated. Thank you!