### PR TITLE
 Allow TRUE instead of \TRUE

### DIFF
--- a/lib/PhpParser/Node/Name/FullyQualified.php
+++ b/lib/PhpParser/Node/Name/FullyQualified.php
@@ -3,6 +3,9 @@
 namespace PhpParser\Node\Name;
 
 class FullyQualified extends \PhpParser\Node\Name {
+
+    public bool $anchorRoot = TRUE;
+    
     /**
      * Checks whether the name is unqualified. (E.g. Name)
      *
@@ -40,7 +43,8 @@ class FullyQualified extends \PhpParser\Node\Name {
     }
 
     public function toCodeString(): string {
-        return '\\' . $this->toString();
+        $prefix = ($this->anchorRoot || count($this->parts) > 1) ? '\\' : '';
+        return $prefix . $this->toString();
     }
 
     public function getType(): string {


### PR DESCRIPTION
I am working on a Rector rule which converts a very large chunk of the remaining procedural code in Drupal to OOP. (Run!)

One problem we found the converted code contains \TRUE instead of TRUE. While of course \TRUE is totally correct, people wanted TRUE and who am I to disagree? I added this to a visitor:

```
                    if (isset($node->name) && $node->name instanceof FullyQualified) {
                        $name = new Node\Name($node->name);
                        if ($name->isUnqualified()) {
                            $node->name = $name;
                            return $node;
                        }
                    }
```

that's quite the hassle though. So I am proposing a property on FullyQualified to start the discussion and if you find it acceptable then I'd add an option to NameResolver which sets this to FALSE. Thanks for your consideration -- and the amazing library.