### PR TITLE
More precise `toLowerString()` return type

### DIFF
--- a/lib/PhpParser/Node/Identifier.php
+++ b/lib/PhpParser/Node/Identifier.php
@@ -53,7 +53,7 @@ class Identifier extends NodeAbstract {
     /**
      * Get lowercased identifier as string.
      *
-     * @psalm-return non-empty-string
+     * @psalm-return non-empty-string&lowercase-string
      * @return string Lowercased identifier as string
      */
     public function toLowerString(): string {

--- a/lib/PhpParser/Node/Name.php
+++ b/lib/PhpParser/Node/Name.php
@@ -129,7 +129,7 @@ class Name extends NodeAbstract {
      * Returns lowercased string representation of the name, without taking the name type into
      * account (e.g., no leading backslash for fully qualified names).
      *
-     * @psalm-return non-empty-string
+     * @psalm-return non-empty-string&lowercase-string
      * @return string Lowercased string representation
      */
     public function toLowerString(): string {


### PR DESCRIPTION
psalm knows the `lowercase-string` type for a few years already and [PHPStan learned it](https://github.com/phpstan/phpstan-src/pull/3438) a few weeks ago.

//cc @VincentLanglet