### PR TITLE
update target.php to new PHP-Parser version

### DIFF
--- a/tools/fuzzing/target.php
+++ b/tools/fuzzing/target.php
@@ -104,7 +104,7 @@ $fuzzer->setTarget(function(string $input) use($lexer, $parser, $prettyPrinter, 
     $stmts = $parser->parse($input);
     $printed = $prettyPrinter->prettyPrintFile($stmts);
 
-    $visitor->setTokens($lexer->getTokens());
+    $visitor->setTokens($lexer->tokenize($input));
     $stmts = $traverser->traverse($stmts);
     if ($visitor->hasProblematicConstruct) {
         return;
@@ -116,7 +116,7 @@ $fuzzer->setTarget(function(string $input) use($lexer, $parser, $prettyPrinter, 
         throw new Error("Failed to parse pretty printer output");
     }
 
-    $visitor->setTokens($lexer->getTokens());
+    $visitor->setTokens($lexer->tokenize($printed));
     $printedStmts = $traverser->traverse($printedStmts);
     $same = $nodeDumper->dump($stmts) == $nodeDumper->dump($printedStmts);
     if (!$same && !preg_match('/<\?php<\?php/i', $input)) {

--- a/tools/fuzzing/target.php
+++ b/tools/fuzzing/target.php
@@ -104,7 +104,7 @@ $fuzzer->setTarget(function(string $input) use($lexer, $parser, $prettyPrinter, 
     $stmts = $parser->parse($input);
     $printed = $prettyPrinter->prettyPrintFile($stmts);
 
-    $visitor->setTokens($lexer->tokenize($input));
+    $visitor->setTokens($parser->getTokens());
     $stmts = $traverser->traverse($stmts);
     if ($visitor->hasProblematicConstruct) {
         return;
@@ -116,7 +116,7 @@ $fuzzer->setTarget(function(string $input) use($lexer, $parser, $prettyPrinter, 
         throw new Error("Failed to parse pretty printer output");
     }
 
-    $visitor->setTokens($lexer->tokenize($printed));
+    $visitor->setTokens($parser->getTokens());
     $printedStmts = $traverser->traverse($printedStmts);
     $same = $nodeDumper->dump($stmts) == $nodeDumper->dump($printedStmts);
     if (!$same && !preg_match('/<\?php<\?php/i', $input)) {


### PR DESCRIPTION
Updates fuzzer target.php to new version of PHP-Parser. The method getTokens() has been removed.

The PHPStan issue is not related to the PR.