### PR TITLE
fix: remove unreachable statement

### DIFF
--- a/lib/PhpParser/ParserAbstract.php
+++ b/lib/PhpParser/ParserAbstract.php
@@ -411,8 +411,6 @@ abstract class ParserAbstract implements Parser {
                 $rule = $state - $this->numNonLeafStates;
             }
         }
-
-        throw new \RuntimeException('Reached end of parser loop');
     }
 
     protected function emitError(Error $error): void {


### PR DESCRIPTION
Removes unreachable statement from ParserAbstract that gives a warning in other PRs, e.g. https://github.com/nikic/PHP-Parser/actions/runs/11901221162/job/33163720547?pr=1040