### PR TITLE
Fix name context on no namespace

### DIFF
--- a/lib/PhpParser/NameContext.php
+++ b/lib/PhpParser/NameContext.php
@@ -123,7 +123,7 @@ class NameContext {
         if ($type !== Stmt\Use_::TYPE_NORMAL && $name->isUnqualified()) {
             if (null === $this->namespace) {
                 // outside of a namespace unaliased unqualified is same as fully qualified
-                return new FullyQualified($name, $name->getAttributes());
+                return $this->getNamespaceRelativeName($name->toString(), strtolower($name->toString()), $type, $name->getAttributes());
             }
 
             // Cannot resolve statically
@@ -249,22 +249,22 @@ class NameContext {
         return null;
     }
 
-    private function getNamespaceRelativeName(string $name, string $lcName, int $type): ?Name {
+    private function getNamespaceRelativeName(string $name, string $lcName, int $type, array $attributes = []): ?Name {
         if (null === $this->namespace) {
-            return new Name($name);
+            return new Name($name, $attributes);
         }
 
         if ($type === Stmt\Use_::TYPE_CONSTANT) {
             // The constants true/false/null always resolve to the global symbols, even inside a
             // namespace, so they may be used without qualification
             if ($lcName === "true" || $lcName === "false" || $lcName === "null") {
-                return new Name($name);
+                return new Name($name, $attributes);
             }
         }
 
         $namespacePrefix = strtolower($this->namespace . '\\');
         if (0 === strpos($lcName, $namespacePrefix)) {
-            return new Name(substr($name, strlen($namespacePrefix)));
+            return new Name(substr($name, strlen($namespacePrefix)), $attributes);
         }
 
         return null;

--- a/test/PhpParser/NodeVisitor/NameResolverTest.php
+++ b/test/PhpParser/NodeVisitor/NameResolverTest.php
@@ -117,8 +117,8 @@ namespace {
     new \Hallo\Bar();
     new \Bar();
     new \Bar();
-    \bar();
-    \hi();
+    bar();
+    hi();
     \Hallo\bar();
     \foo\bar();
     \bar();
@@ -197,7 +197,7 @@ class A extends B implements C, D {
 
     #[X]
     const C = 1;
-    
+
     public const X A = X::Bar;
     public const X\Foo B = X\Foo::Bar;
     public const \X\Foo C = \X\Foo::Bar;


### PR DESCRIPTION
Ref https://getrector.com/ast/d50f4d493f7061f3c419397a744a49e92409c3ce?nodeId=1

which `\true` should be `true` on no namespace.