### PR TITLE
Use more precise list-types for getter methods

### DIFF
--- a/lib/PhpParser/Node/Stmt/ClassLike.php
+++ b/lib/PhpParser/Node/Stmt/ClassLike.php
@@ -17,7 +17,7 @@ abstract class ClassLike extends Node\Stmt {
     public ?Node\Name $namespacedName;
 
     /**
-     * @return TraitUse[]
+     * @return list<TraitUse>
      */
     public function getTraitUses(): array {
         $traitUses = [];
@@ -30,7 +30,7 @@ abstract class ClassLike extends Node\Stmt {
     }
 
     /**
-     * @return ClassConst[]
+     * @return list<ClassConst>
      */
     public function getConstants(): array {
         $constants = [];
@@ -43,7 +43,7 @@ abstract class ClassLike extends Node\Stmt {
     }
 
     /**
-     * @return Property[]
+     * @return list<Property>
      */
     public function getProperties(): array {
         $properties = [];
@@ -78,7 +78,7 @@ abstract class ClassLike extends Node\Stmt {
     /**
      * Gets all methods defined directly in this class/interface/trait
      *
-     * @return ClassMethod[]
+     * @return list<ClassMethod>
      */
     public function getMethods(): array {
         $methods = [];

--- a/lib/PhpParser/NodeVisitor/FindingVisitor.php
+++ b/lib/PhpParser/NodeVisitor/FindingVisitor.php
@@ -12,7 +12,7 @@ use PhpParser\NodeVisitorAbstract;
 class FindingVisitor extends NodeVisitorAbstract {
     /** @var callable Filter callback */
     protected $filterCallback;
-    /** @var Node[] Found nodes */
+    /** @var list<Node> Found nodes */
     protected array $foundNodes;
 
     public function __construct(callable $filterCallback) {
@@ -24,7 +24,7 @@ class FindingVisitor extends NodeVisitorAbstract {
      *
      * Nodes are returned in pre-order.
      *
-     * @return Node[] Found nodes
+     * @return list<Node> Found nodes
      */
     public function getFoundNodes(): array {
         return $this->foundNodes;


### PR DESCRIPTION
searched the codebase with `(?<!getSubNodeNam)es\(\):` and added `list`-types where appropriate