### PR TITLE
PHPunit : require_once instead of require

### DIFF
--- a/lib/PhpParser/Node/Expr/ArrayItem.php
+++ b/lib/PhpParser/Node/Expr/ArrayItem.php
@@ -2,7 +2,7 @@
 
 namespace PhpParser\Node\Expr;
 
-require __DIR__ . '/../ArrayItem.php';
+require_once __DIR__ . '/../ArrayItem.php';
 
 if (false) {
     // For classmap-authoritative support.

--- a/lib/PhpParser/Node/Expr/ClosureUse.php
+++ b/lib/PhpParser/Node/Expr/ClosureUse.php
@@ -2,7 +2,7 @@
 
 namespace PhpParser\Node\Expr;
 
-require __DIR__ . '/../ClosureUse.php';
+require_once __DIR__ . '/../ClosureUse.php';
 
 if (false) {
     // For classmap-authoritative support.

--- a/lib/PhpParser/Node/Scalar/EncapsedStringPart.php
+++ b/lib/PhpParser/Node/Scalar/EncapsedStringPart.php
@@ -4,7 +4,7 @@ namespace PhpParser\Node\Scalar;
 
 use PhpParser\Node\InterpolatedStringPart;
 
-require __DIR__ . '/../InterpolatedStringPart.php';
+require_once __DIR__ . '/../InterpolatedStringPart.php';
 
 if (false) {
     // For classmap-authoritative support.

--- a/lib/PhpParser/Node/Scalar/LNumber.php
+++ b/lib/PhpParser/Node/Scalar/LNumber.php
@@ -2,7 +2,7 @@
 
 namespace PhpParser\Node\Scalar;
 
-require __DIR__ . '/Int_.php';
+require_once __DIR__ . '/Int_.php';
 
 if (false) {
     // For classmap-authoritative support.

--- a/lib/PhpParser/Node/Stmt/DeclareDeclare.php
+++ b/lib/PhpParser/Node/Stmt/DeclareDeclare.php
@@ -4,7 +4,7 @@ namespace PhpParser\Node\Stmt;
 
 use PhpParser\Node\DeclareItem;
 
-require __DIR__ . '/../DeclareItem.php';
+require_once __DIR__ . '/../DeclareItem.php';
 
 if (false) {
     // For classmap-authoritative support.

--- a/lib/PhpParser/Node/Stmt/PropertyProperty.php
+++ b/lib/PhpParser/Node/Stmt/PropertyProperty.php
@@ -4,7 +4,7 @@ namespace PhpParser\Node\Stmt;
 
 use PhpParser\Node\PropertyItem;
 
-require __DIR__ . '/../PropertyItem.php';
+require_once __DIR__ . '/../PropertyItem.php';
 
 if (false) {
     // For classmap-authoritative support.

--- a/lib/PhpParser/Node/Stmt/StaticVar.php
+++ b/lib/PhpParser/Node/Stmt/StaticVar.php
@@ -2,7 +2,7 @@
 
 namespace PhpParser\Node\Stmt;
 
-require __DIR__ . '/../StaticVar.php';
+require_once __DIR__ . '/../StaticVar.php';
 
 if (false) {
     // For classmap-authoritative support.


### PR DESCRIPTION
When running phpunit:
```
php ./vendor/bin/phpunit --configuration ./phpunit.xml
```
I got such issues: 

```
PHP Fatal error:  Cannot declare class PhpParser\Node\PropertyItem, because the name is already in use in /home/user/my/x/tests/vendor/nikic/php-parser/lib/PhpParser/Node/PropertyItem.php on line 8
PHP Stack trace:
PHP   1. {main}() /home/user/my/x/tests/vendor/bin/phpunit:0
PHP   2. include() /home/user/my/x/tests/vendor/bin/phpunit:122
PHP   3. PHPUnit\TextUI\Application->run($argv = [0 => './vendor/bin/phpunit', 1 => '--configuration', 2 => './phpunit.xml']) /home/user/my/x/tests/vendor/phpunit/phpunit/phpunit:104
PHP   4. PHPUnit\TextUI\Application->buildTestSuite(...) /home/user/my/x/tests/vendor/phpunit/phpunit/src/TextUI/Application.php:181
PHP   5. PHPUnit\TextUI\Configuration\TestSuiteBuilder->build() /home/user/my/x/tests/vendor/phpunit/phpunit/src/TextUI/Application.php:418
PHP   6. PHPUnit\TextUI\XmlConfiguration\TestSuiteMapper->map() /home/user/my/x/tests/vendor/phpunit/phpunit/src/TextUI/Configuration/TestSuiteBuilder.php:75
PHP   7. PHPUnit\Framework\TestSuite->addTestFile($filename = '/home/user/my/x/tests/vendor/nikic/php-parser/lib/PhpParser/Node/Stmt/PropertyProperty.php', $groups = []) /home/user/my/x/tests/vendor/phpunit/phpunit/src/TextUI/Configuration/Xml/TestSuiteMapper.php:105
PHP   8. PHPUnit\Runner\TestSuiteLoader->load($suiteClassFile = '/home/user/my/x/tests/vendor/nikic/php-parser/lib/PhpParser/Node/Stmt/PropertyProperty.php') /home/user/my/x/tests/vendor/phpunit/phpunit/src/Framework/TestSuite.php:225
PHP   9. PHPUnit\Runner\TestSuiteLoader->loadSuiteClassFile($suiteClassFile = '/home/user/my/x/tests/vendor/nikic/php-parser/lib/PhpParser/Node/Stmt/PropertyProperty.php') /home/user/my/x/tests/vendor/phpunit/phpunit/src/Runner/TestSuiteLoader.php:49
PHP  10. require_once() /home/user/my/x/tests/vendor/phpunit/phpunit/src/Runner/TestSuiteLoader.php:116
PHP  11. require() /home/user/my/x/tests/vendor/nikic/php-parser/lib/PhpParser/Node/Stmt/PropertyProperty.php:7
```

only replacing them with `require_once` fixed my case