### PR TITLE
Declare CallLike $args as list

### DIFF
--- a/lib/PhpParser/Node/Expr/FuncCall.php
+++ b/lib/PhpParser/Node/Expr/FuncCall.php
@@ -8,14 +8,14 @@ use PhpParser\Node\Expr;
 class FuncCall extends CallLike {
     /** @var Node\Name|Expr Function name */
     public Node $name;
-    /** @var array<Node\Arg|Node\VariadicPlaceholder> Arguments */
+    /** @var list<Node\Arg|Node\VariadicPlaceholder> Arguments */
     public array $args;
 
     /**
      * Constructs a function call node.
      *
      * @param Node\Name|Expr $name Function name
-     * @param array<Node\Arg|Node\VariadicPlaceholder> $args Arguments
+     * @param list<Node\Arg|Node\VariadicPlaceholder> $args Arguments
      * @param array<string, mixed> $attributes Additional attributes
      */
     public function __construct(Node $name, array $args = [], array $attributes = []) {

--- a/lib/PhpParser/Node/Expr/MethodCall.php
+++ b/lib/PhpParser/Node/Expr/MethodCall.php
@@ -13,7 +13,7 @@ class MethodCall extends CallLike {
     public Expr $var;
     /** @var Identifier|Expr Method name */
     public Node $name;
-    /** @var array<Arg|VariadicPlaceholder> Arguments */
+    /** @var list<Arg|VariadicPlaceholder> Arguments */
     public array $args;
 
     /**
@@ -21,7 +21,7 @@ class MethodCall extends CallLike {
      *
      * @param Expr $var Variable holding object
      * @param string|Identifier|Expr $name Method name
-     * @param array<Arg|VariadicPlaceholder> $args Arguments
+     * @param list<Arg|VariadicPlaceholder> $args Arguments
      * @param array<string, mixed> $attributes Additional attributes
      */
     public function __construct(Expr $var, $name, array $args = [], array $attributes = []) {

--- a/lib/PhpParser/Node/Expr/New_.php
+++ b/lib/PhpParser/Node/Expr/New_.php
@@ -10,14 +10,14 @@ use PhpParser\Node\VariadicPlaceholder;
 class New_ extends CallLike {
     /** @var Node\Name|Expr|Node\Stmt\Class_ Class name */
     public Node $class;
-    /** @var array<Arg|VariadicPlaceholder> Arguments */
+    /** @var list<Arg|VariadicPlaceholder> Arguments */
     public array $args;
 
     /**
      * Constructs a function call node.
      *
      * @param Node\Name|Expr|Node\Stmt\Class_ $class Class name (or class node for anonymous classes)
-     * @param array<Arg|VariadicPlaceholder> $args Arguments
+     * @param list<Arg|VariadicPlaceholder> $args Arguments
      * @param array<string, mixed> $attributes Additional attributes
      */
     public function __construct(Node $class, array $args = [], array $attributes = []) {

--- a/lib/PhpParser/Node/Expr/NullsafeMethodCall.php
+++ b/lib/PhpParser/Node/Expr/NullsafeMethodCall.php
@@ -13,7 +13,7 @@ class NullsafeMethodCall extends CallLike {
     public Expr $var;
     /** @var Identifier|Expr Method name */
     public Node $name;
-    /** @var array<Arg|VariadicPlaceholder> Arguments */
+    /** @var list<Arg|VariadicPlaceholder> Arguments */
     public array $args;
 
     /**
@@ -21,7 +21,7 @@ class NullsafeMethodCall extends CallLike {
      *
      * @param Expr $var Variable holding object
      * @param string|Identifier|Expr $name Method name
-     * @param array<Arg|VariadicPlaceholder> $args Arguments
+     * @param list<Arg|VariadicPlaceholder> $args Arguments
      * @param array<string, mixed> $attributes Additional attributes
      */
     public function __construct(Expr $var, $name, array $args = [], array $attributes = []) {

--- a/lib/PhpParser/Node/Expr/StaticCall.php
+++ b/lib/PhpParser/Node/Expr/StaticCall.php
@@ -13,7 +13,7 @@ class StaticCall extends CallLike {
     public Node $class;
     /** @var Identifier|Expr Method name */
     public Node $name;
-    /** @var array<Arg|VariadicPlaceholder> Arguments */
+    /** @var list<Arg|VariadicPlaceholder> Arguments */
     public array $args;
 
     /**
@@ -21,7 +21,7 @@ class StaticCall extends CallLike {
      *
      * @param Node\Name|Expr $class Class name
      * @param string|Identifier|Expr $name Method name
-     * @param array<Arg|VariadicPlaceholder> $args Arguments
+     * @param list<Arg|VariadicPlaceholder> $args Arguments
      * @param array<string, mixed> $attributes Additional attributes
      */
     public function __construct(Node $class, $name, array $args = [], array $attributes = []) {


### PR DESCRIPTION
having a more precise type helps to prevent false positives when implementing e.g. PHPStan rules

```
private function findInputTypeIdsInNew(New_ $newExpr, ClassReflection $class, Scope $scope): array
    {
        if (\count($newExpr->args) === 0) {
            // more logic
            return [];
        }

        $firstArg = $newExpr->args[0]; // Offset 0 might not exist on non-empty-array<PhpParser\Node\Arg|PhpParser\Node\VariadicPlaceholder>.
        if (! $firstArg instanceof Arg) {
            return [];
        }
```

happens when PHPStan is configured with [reportPossiblyNonexistentGeneralArrayOffset](https://phpstan.org/config-reference#reportpossiblynonexistentgeneralarrayoffset)