### PR TITLE
Minor spelling `now longer` -> `no longer`

### DIFF
--- a/UPGRADE-5.0.md
+++ b/UPGRADE-5.0.md
@@ -308,7 +308,7 @@ PhpParser\Node\Stmt\Class_::VISIBILITY_MODIFIER_MASK -> PhpParser\Modifiers::VIS
 
 ### Changes to node constructors
 
-Node constructor arguments accepting types now longer accept plain strings. Either an `Identifier` or `Name` (or `ComplexType`) should be passed instead. This affects the following constructor arguments:
+Node constructor arguments accepting types no longer accept plain strings. Either an `Identifier` or `Name` (or `ComplexType`) should be passed instead. This affects the following constructor arguments:
 
 * The `'returnType'` key of `$subNodes` argument of `Node\Expr\ArrowFunction`.
 * The `'returnType'` key of `$subNodes` argument of `Node\Expr\Closure`.


### PR DESCRIPTION
Small spelling mistake in the documentation. 

The relevant [PhpDoc in 5.x](https://github.com/nikic/PHP-Parser/blob/4a21235f7e56e713259a6f76bf4b5ea08502b9dc/lib/PhpParser/Node/Stmt/ClassMethod.php#L54) is far better than [4.x](https://github.com/nikic/PHP-Parser/blob/715f4d25e225bc47b293a8b997fe6ce99bf987d2/lib/PhpParser/Node/Stmt/ClassMethod.php#L49) :)