### PR TITLE
feat: add CallLike::getArg() method

### DIFF
--- a/lib/PhpParser/Node/Expr/CallLike.php
+++ b/lib/PhpParser/Node/Expr/CallLike.php
@@ -32,4 +32,29 @@ abstract class CallLike extends Expr {
         assert(!$this->isFirstClassCallable());
         return $this->getRawArgs();
     }
+
+    /**
+     * Retrieves a specific argument from the raw arguments.
+     *
+     * Returns the named argument that matches the given `$name`, or the
+     * positional (unnamed) argument that exists at the given `$position`,
+     * otherwise, returns `null` for first-class callables or if no match is found.
+     */
+    public function getArg(string $name, int $position): ?Arg {
+        if ($this->isFirstClassCallable()) {
+            return null;
+        }
+        foreach ($this->getRawArgs() as $i => $arg) {
+            if ($arg->unpack) {
+                continue;
+            }
+            if (
+                ($arg->name !== null && $arg->name->toString() === $name)
+                || ($arg->name === null && $i === $position)
+            ) {
+                return $arg;
+            }
+        }
+        return null;
+    }
 }

--- a/test/PhpParser/Node/Expr/CallableLikeTest.php
+++ b/test/PhpParser/Node/Expr/CallableLikeTest.php
@@ -3,6 +3,7 @@
 namespace PhpParser\Node\Expr;
 
 use PhpParser\Node\Arg;
+use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
 use PhpParser\Node\Scalar\Int_;
 use PhpParser\Node\VariadicPlaceholder;
@@ -16,6 +17,13 @@ class CallableLikeTest extends \PHPUnit\Framework\TestCase {
         if (!$isFirstClassCallable) {
             $this->assertSame($node->getRawArgs(), $node->getArgs());
         }
+    }
+
+    /**
+     * @dataProvider provideTestGetArg
+     */
+    public function testGetArg(CallLike $node, ?Arg $expected): void {
+        $this->assertSame($expected, $node->getArg('bar', 1));
     }
 
     public static function provideTestIsFirstClassCallable() {
@@ -33,6 +41,58 @@ class CallableLikeTest extends \PHPUnit\Framework\TestCase {
             // This is not legal code, but accepted by the parser.
             [new New_(new Name('Test'), $callableArgs), true],
             [new NullsafeMethodCall(new Variable('this'), 'test', $callableArgs), true],
+        ];
+    }
+
+    public static function provideTestGetArg() {
+        $foo = new Arg(new Int_(1));
+        $namedFoo = new Arg(new Int_(1), false, false, [], new Identifier('foo'));
+        $bar = new Arg(new Int_(2));
+        $namedBar = new Arg(new Int_(2), false, false, [], new Identifier('bar'));
+        $unpack = new Arg(new Int_(3), false, true);
+        $callableArgs = [new VariadicPlaceholder()];
+        return [
+            [new FuncCall(new Name('test'), [$foo]), null],
+            [new FuncCall(new Name('test'), [$namedFoo]), null],
+            [new FuncCall(new Name('test'), [$foo, $bar]), $bar],
+            [new FuncCall(new Name('test'), [$namedBar]), $namedBar],
+            [new FuncCall(new Name('test'), [$namedFoo, $namedBar]), $namedBar],
+            [new FuncCall(new Name('test'), [$namedBar, $namedFoo]), $namedBar],
+            [new FuncCall(new Name('test'), [$namedFoo, $unpack]), null],
+            [new FuncCall(new Name('test'), $callableArgs), null],
+            [new MethodCall(new Variable('this'), 'test', [$foo]), null],
+            [new MethodCall(new Variable('this'), 'test', [$namedFoo]), null],
+            [new MethodCall(new Variable('this'), 'test', [$foo, $bar]), $bar],
+            [new MethodCall(new Variable('this'), 'test', [$namedBar]), $namedBar],
+            [new MethodCall(new Variable('this'), 'test', [$namedFoo, $namedBar]), $namedBar],
+            [new MethodCall(new Variable('this'), 'test', [$namedBar, $namedFoo]), $namedBar],
+            [new MethodCall(new Variable('this'), 'test', [$namedFoo, $unpack]), null],
+            [new MethodCall(new Variable('this'), 'test', $callableArgs), null],
+            [new StaticCall(new Name('Test'), 'test', [$foo]), null],
+            [new StaticCall(new Name('Test'), 'test', [$namedFoo]), null],
+            [new StaticCall(new Name('Test'), 'test', [$foo, $bar]), $bar],
+            [new StaticCall(new Name('Test'), 'test', [$namedBar]), $namedBar],
+            [new StaticCall(new Name('Test'), 'test', [$namedFoo, $namedBar]), $namedBar],
+            [new StaticCall(new Name('Test'), 'test', [$namedBar, $namedFoo]), $namedBar],
+            [new StaticCall(new Name('Test'), 'test', [$namedFoo, $unpack]), null],
+            [new StaticCall(new Name('Test'), 'test', $callableArgs), null],
+            [new New_(new Name('test'), [$foo]), null],
+            [new New_(new Name('test'), [$namedFoo]), null],
+            [new New_(new Name('test'), [$foo, $bar]), $bar],
+            [new New_(new Name('test'), [$namedBar]), $namedBar],
+            [new New_(new Name('test'), [$namedFoo, $namedBar]), $namedBar],
+            [new New_(new Name('test'), [$namedBar, $namedFoo]), $namedBar],
+            [new New_(new Name('test'), [$namedFoo, $unpack]), null],
+            [new NullsafeMethodCall(new Variable('this'), 'test', [$foo]), null],
+            [new NullsafeMethodCall(new Variable('this'), 'test', [$namedFoo]), null],
+            [new NullsafeMethodCall(new Variable('this'), 'test', [$foo, $bar]), $bar],
+            [new NullsafeMethodCall(new Variable('this'), 'test', [$namedBar]), $namedBar],
+            [new NullsafeMethodCall(new Variable('this'), 'test', [$namedFoo, $namedBar]), $namedBar],
+            [new NullsafeMethodCall(new Variable('this'), 'test', [$namedBar, $namedFoo]), $namedBar],
+            [new NullsafeMethodCall(new Variable('this'), 'test', [$namedFoo, $unpack]), null],
+            // This is not legal code, but accepted by the parser.
+            [new New_(new Name('Test'), $callableArgs), null],
+            [new NullsafeMethodCall(new Variable('this'), 'test', $callableArgs), null],
         ];
     }
 }


### PR DESCRIPTION
Hello!

This method returns the named argument that matches the given `$name`, or the positional (unnamed) argument that exists at the given `$position`, otherwise, returns `null` for first-class callables or if no match is found.

### Motivation

I found myself duplicating this logic over and over again, so thought it would be a good idea to just PR it.

For a given CallLike, I often need to target a particular *parameter*. Take for example this function signature:
```php
function test(int $foo = 24, int $bar = 42);
```
and let's say that I need to do something with `$bar` (which has name `bar` and is at position `1`) if it's provided in the call. Now I can simply use:
```php
$arg = $node->getArg('bar', 1);
```
which would return the following:
```php
test(); // null
test(...); // null
test(24, 42); // Arg(42)
test(24); // null
test(foo: 24); // null
test(bar: 42); // Arg(42, 'bar')
test(foo: 24, bar: 42); // Arg(42, 'bar')
test(bar: 42, foo: 24); // Arg(42, 'bar')
```
Thanks!