### PR TITLE
Use @deprecated above class to allow static analyzer like PHPStan detect deprecation

### DIFF
--- a/lib/PhpParser/Node/Expr/ArrayItem.php
+++ b/lib/PhpParser/Node/Expr/ArrayItem.php
@@ -5,7 +5,11 @@ namespace PhpParser\Node\Expr;
 require __DIR__ . '/../ArrayItem.php';
 
 if (false) {
-    // For classmap-authoritative support.
+    /**
+     * For classmap-authoritative support.
+     *
+     * @deprecated use \PhpParser\Node\ArrayItem instead.
+     */
     class ArrayItem extends \PhpParser\Node\ArrayItem {
     }
 }

--- a/lib/PhpParser/Node/Expr/ClosureUse.php
+++ b/lib/PhpParser/Node/Expr/ClosureUse.php
@@ -5,7 +5,11 @@ namespace PhpParser\Node\Expr;
 require __DIR__ . '/../ClosureUse.php';
 
 if (false) {
-    // For classmap-authoritative support.
+    /**
+     * For classmap-authoritative support.
+     *
+     * @deprecated use \PhpParser\Node\ClosureUse instead.
+     */
     class ClosureUse extends \PhpParser\Node\ClosureUse {
     }
 }

--- a/lib/PhpParser/Node/Scalar/DNumber.php
+++ b/lib/PhpParser/Node/Scalar/DNumber.php
@@ -5,7 +5,11 @@ namespace PhpParser\Node\Scalar;
 require __DIR__ . '/Float_.php';
 
 if (false) {
-    // For classmap-authoritative support.
+    /**
+     * For classmap-authoritative support.
+     *
+     * @deprecated use \PhpParser\Node\Scalar\Float_ instead.
+     */
     class DNumber extends Float_ {
     }
 }

--- a/lib/PhpParser/Node/Scalar/Encapsed.php
+++ b/lib/PhpParser/Node/Scalar/Encapsed.php
@@ -5,7 +5,11 @@ namespace PhpParser\Node\Scalar;
 require __DIR__ . '/InterpolatedString.php';
 
 if (false) {
-    // For classmap-authoritative support.
+    /**
+     * For classmap-authoritative support.
+     *
+     * @deprecated use \PhpParser\Node\Scalar\InterpolatedString instead.
+     */
     class Encapsed extends InterpolatedString {
     }
 }

--- a/lib/PhpParser/Node/Scalar/EncapsedStringPart.php
+++ b/lib/PhpParser/Node/Scalar/EncapsedStringPart.php
@@ -7,7 +7,11 @@ use PhpParser\Node\InterpolatedStringPart;
 require __DIR__ . '/../InterpolatedStringPart.php';
 
 if (false) {
-    // For classmap-authoritative support.
+    /**
+     * For classmap-authoritative support.
+     *
+     * @deprecated use \PhpParser\Node\InterpolatedStringPart instead.
+     */
     class EncapsedStringPart extends InterpolatedStringPart {
     }
 }

--- a/lib/PhpParser/Node/Scalar/LNumber.php
+++ b/lib/PhpParser/Node/Scalar/LNumber.php
@@ -5,7 +5,11 @@ namespace PhpParser\Node\Scalar;
 require __DIR__ . '/Int_.php';
 
 if (false) {
-    // For classmap-authoritative support.
+    /**
+     * For classmap-authoritative support.
+     *
+     * @deprecated use \PhpParser\Node\Scalar\Int_ instead.
+     */
     class LNumber extends Int_ {
     }
 }

--- a/lib/PhpParser/Node/Stmt/DeclareDeclare.php
+++ b/lib/PhpParser/Node/Stmt/DeclareDeclare.php
@@ -7,7 +7,11 @@ use PhpParser\Node\DeclareItem;
 require __DIR__ . '/../DeclareItem.php';
 
 if (false) {
-    // For classmap-authoritative support.
+    /**
+     * For classmap-authoritative support.
+     *
+     * @deprecated use \PhpParser\Node\DeclareItem instead.
+     */
     class DeclareDeclare extends DeclareItem {
     }
 }

--- a/lib/PhpParser/Node/Stmt/PropertyProperty.php
+++ b/lib/PhpParser/Node/Stmt/PropertyProperty.php
@@ -7,7 +7,11 @@ use PhpParser\Node\PropertyItem;
 require __DIR__ . '/../PropertyItem.php';
 
 if (false) {
-    // For classmap-authoritative support.
+    /**
+     * For classmap-authoritative support.
+     *
+     * @deprecated use \PhpParser\Node\PropertyItem instead.
+     */
     class PropertyProperty extends PropertyItem {
     }
 }

--- a/lib/PhpParser/Node/Stmt/StaticVar.php
+++ b/lib/PhpParser/Node/Stmt/StaticVar.php
@@ -5,7 +5,11 @@ namespace PhpParser\Node\Stmt;
 require __DIR__ . '/../StaticVar.php';
 
 if (false) {
-    // For classmap-authoritative support.
+    /**
+     * For classmap-authoritative support.
+     *
+     * @deprecated use \PhpParser\Node\StaticVar instead.
+     */
     class StaticVar extends \PhpParser\Node\StaticVar {
     }
 }

--- a/lib/PhpParser/Node/Stmt/UseUse.php
+++ b/lib/PhpParser/Node/Stmt/UseUse.php
@@ -7,7 +7,11 @@ use PhpParser\Node\UseItem;
 require __DIR__ . '/../UseItem.php';
 
 if (false) {
-    // For classmap-authoritative support.
+    /**
+     * For classmap-authoritative support.
+     *
+     * @deprecated use \PhpParser\Node\UseItem instead.
+     */
     class UseUse extends UseItem {
     }
 }


### PR DESCRIPTION
@TomasVotruba per our discussion at https://github.com/rectorphp/rector-phpunit/pull/513#issuecomment-3200861058