### PR TITLE
Deprecate Double cast

### DIFF
--- a/grammar/php.y
+++ b/grammar/php.y
@@ -1110,7 +1110,7 @@ expr:
     | T_DOUBLE_CAST expr
           { $attrs = attributes();
             $attrs['kind'] = $this->getFloatCastKind($1);
-            $$ = new Expr\Cast\Double($2, $attrs); }
+            $$ = new Expr\Cast\Float_($2, $attrs); }
     | T_STRING_CAST expr
           { $attrs = attributes();
             $attrs['kind'] = $this->getStringCastKind($1);

--- a/lib/PhpParser/Node/Expr/Cast/Double.php
+++ b/lib/PhpParser/Node/Expr/Cast/Double.php
@@ -2,15 +2,17 @@
 
 namespace PhpParser\Node\Expr\Cast;
 
-use PhpParser\Node\Expr\Cast;
+require __DIR__ . '/Float_.php';
 
-class Double extends Cast {
-    // For use in "kind" attribute
-    public const KIND_DOUBLE = 1; // "double" syntax
-    public const KIND_FLOAT = 2;  // "float" syntax
-    public const KIND_REAL = 3; // "real" syntax
-
-    public function getType(): string {
-        return 'Expr_Cast_Double';
+if (false) {
+    /**
+     * For classmap-authoritative support.
+     *
+     * @deprecated use \PhpParser\Node\Expr\Cast\Float_ instead.
+     */
+    class Double extends Float_ {
+        public function getType(): string {
+            return 'Expr_Cast_Double';
+        }
     }
 }

--- a/lib/PhpParser/Node/Expr/Cast/Float_.php
+++ b/lib/PhpParser/Node/Expr/Cast/Float_.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types=1);
+
+namespace PhpParser\Node\Expr\Cast;
+
+use PhpParser\Node\Expr\Cast;
+
+class Float_ extends Cast {
+    // For use in "kind" attribute
+    public const KIND_DOUBLE = 1; // "double" syntax
+    public const KIND_FLOAT = 2;  // "float" syntax
+    public const KIND_REAL = 3; // "real" syntax
+
+    public function getType(): string {
+        return 'Expr_Cast_Float';
+    }
+}
+
+// @deprecated compatibility alias
+class_alias(Float_::class, Double::class);

--- a/lib/PhpParser/Parser/Php7.php
+++ b/lib/PhpParser/Parser/Php7.php
@@ -2485,7 +2485,7 @@ class Php7 extends \PhpParser\ParserAbstract
             488 => static function ($self, $stackPos) {
                  $attrs = $self->getAttributes($self->tokenStartStack[$stackPos-(2-1)], $self->tokenEndStack[$stackPos]);
             $attrs['kind'] = $self->getFloatCastKind($self->semStack[$stackPos-(2-1)]);
-            $self->semValue = new Expr\Cast\Double($self->semStack[$stackPos-(2-2)], $attrs);
+            $self->semValue = new Expr\Cast\Float_($self->semStack[$stackPos-(2-2)], $attrs);
             },
             489 => static function ($self, $stackPos) {
                  $attrs = $self->getAttributes($self->tokenStartStack[$stackPos-(2-1)], $self->tokenEndStack[$stackPos]);

--- a/lib/PhpParser/Parser/Php8.php
+++ b/lib/PhpParser/Parser/Php8.php
@@ -2486,7 +2486,7 @@ class Php8 extends \PhpParser\ParserAbstract
             491 => static function ($self, $stackPos) {
                  $attrs = $self->getAttributes($self->tokenStartStack[$stackPos-(2-1)], $self->tokenEndStack[$stackPos]);
             $attrs['kind'] = $self->getFloatCastKind($self->semStack[$stackPos-(2-1)]);
-            $self->semValue = new Expr\Cast\Double($self->semStack[$stackPos-(2-2)], $attrs);
+            $self->semValue = new Expr\Cast\Float_($self->semStack[$stackPos-(2-2)], $attrs);
             },
             492 => static function ($self, $stackPos) {
                  $attrs = $self->getAttributes($self->tokenStartStack[$stackPos-(2-1)], $self->tokenEndStack[$stackPos]);

--- a/lib/PhpParser/ParserAbstract.php
+++ b/lib/PhpParser/ParserAbstract.php
@@ -10,7 +10,7 @@ namespace PhpParser;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\Array_;
-use PhpParser\Node\Expr\Cast\Double;
+use PhpParser\Node\Expr\Cast\Float_;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\InterpolatedStringPart;
 use PhpParser\Node\Name;
@@ -726,14 +726,14 @@ abstract class ParserAbstract implements Parser {
     protected function getFloatCastKind(string $cast): int {
         $cast = strtolower($cast);
         if (strpos($cast, 'float') !== false) {
-            return Double::KIND_FLOAT;
+            return Float_::KIND_FLOAT;
         }
 
         if (strpos($cast, 'real') !== false) {
-            return Double::KIND_REAL;
+            return Float_::KIND_REAL;
         }
 
-        return Double::KIND_DOUBLE;
+        return Float_::KIND_DOUBLE;
     }
 
     protected function getIntCastKind(string $cast): int {

--- a/lib/PhpParser/PrettyPrinter/Standard.php
+++ b/lib/PhpParser/PrettyPrinter/Standard.php
@@ -488,17 +488,21 @@ class Standard extends PrettyPrinterAbstract {
         return $this->pPrefixOp(Cast\Int_::class, '(int) ', $node->expr, $precedence, $lhsPrecedence);
     }
 
-    protected function pExpr_Cast_Double(Cast\Double $node, int $precedence, int $lhsPrecedence): string {
-        $kind = $node->getAttribute('kind', Cast\Double::KIND_DOUBLE);
-        if ($kind === Cast\Double::KIND_DOUBLE) {
+    protected function pExpr_Cast_Double(Cast\Float_ $node, int $precedence, int $lhsPrecedence): string {
+        $kind = $node->getAttribute('kind', Cast\Float_::KIND_DOUBLE);
+        if ($kind === Cast\Float_::KIND_DOUBLE) {
             $cast = '(double)';
-        } elseif ($kind === Cast\Double::KIND_FLOAT) {
+        } elseif ($kind === Cast\Float_::KIND_FLOAT) {
             $cast = '(float)';
         } else {
-            assert($kind === Cast\Double::KIND_REAL);
+            assert($kind === Cast\Float_::KIND_REAL);
             $cast = '(real)';
         }
-        return $this->pPrefixOp(Cast\Double::class, $cast . ' ', $node->expr, $precedence, $lhsPrecedence);
+        return $this->pPrefixOp(Cast\Float_::class, $cast . ' ', $node->expr, $precedence, $lhsPrecedence);
+    }
+
+    protected function pExpr_Cast_Float(Cast\Float_ $node, int $precedence, int $lhsPrecedence): string {
+        return $this->pExpr_Cast_Double($node, $precedence, $lhsPrecedence);
     }
 
     protected function pExpr_Cast_String(Cast\String_ $node, int $precedence, int $lhsPrecedence): string {

--- a/lib/PhpParser/PrettyPrinterAbstract.php
+++ b/lib/PhpParser/PrettyPrinterAbstract.php
@@ -46,6 +46,7 @@ abstract class PrettyPrinterAbstract implements PrettyPrinter {
         Expr\UnaryMinus::class         => [ 10,  -1,  -1],
         Cast\Int_::class               => [ 10,  -1,  -1],
         Cast\Double::class             => [ 10,  -1,  -1],
+        Cast\Float_::class             => [ 10,  -1,  -1],
         Cast\String_::class            => [ 10,  -1,  -1],
         Cast\Array_::class             => [ 10,  -1,  -1],
         Cast\Object_::class            => [ 10,  -1,  -1],
@@ -1386,7 +1387,7 @@ abstract class PrettyPrinterAbstract implements PrettyPrinter {
 
         $prefixOps = [
             Expr\Clone_::class, Expr\BitwiseNot::class, Expr\BooleanNot::class, Expr\UnaryPlus::class, Expr\UnaryMinus::class,
-            Cast\Int_::class, Cast\Double::class, Cast\String_::class, Cast\Array_::class,
+            Cast\Int_::class, Cast\Double::class, Cast\Float_::class, Cast\String_::class, Cast\Array_::class,
             Cast\Object_::class, Cast\Bool_::class, Cast\Unset_::class, Expr\ErrorSuppress::class,
             Expr\YieldFrom::class, Expr\Print_::class, Expr\Include_::class,
             Expr\Assign::class, Expr\AssignRef::class, AssignOp\Plus::class, AssignOp\Minus::class,

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -112,6 +112,12 @@ parameters:
 			message: '#^If condition is always false\.$#'
 			identifier: if.alwaysFalse
 			count: 1
+			path: lib/PhpParser/Node/Expr/Cast/Double.php
+
+		-
+			message: '#^If condition is always false\.$#'
+			identifier: if.alwaysFalse
+			count: 1
 			path: lib/PhpParser/Node/Expr/ClosureUse.php
 
 		-

--- a/test/PhpParser/ParserTestAbstract.php
+++ b/test/PhpParser/ParserTestAbstract.php
@@ -173,10 +173,10 @@ EOC;
             ["namespace Foo;", ['kind' => Stmt\Namespace_::KIND_SEMICOLON]],
             ["namespace Foo {}", ['kind' => Stmt\Namespace_::KIND_BRACED]],
             ["namespace {}", ['kind' => Stmt\Namespace_::KIND_BRACED]],
-            ["(float) 5.0", ['kind' => Expr\Cast\Double::KIND_FLOAT]],
-            ["(double) 5.0", ['kind' => Expr\Cast\Double::KIND_DOUBLE]],
-            ["(real) 5.0", ['kind' => Expr\Cast\Double::KIND_REAL]],
-            [" (  REAL )  5.0", ['kind' => Expr\Cast\Double::KIND_REAL]],
+            ["(float) 5.0", ['kind' => Expr\Cast\Float_::KIND_FLOAT]],
+            ["(double) 5.0", ['kind' => Expr\Cast\Float_::KIND_DOUBLE]],
+            ["(real) 5.0", ['kind' => Expr\Cast\Float_::KIND_REAL]],
+            [" (  REAL )  5.0", ['kind' => Expr\Cast\Float_::KIND_REAL]],
         ];
     }
 

--- a/test/code/parser/expr/cast.test
+++ b/test/code/parser/expr/cast.test
@@ -36,21 +36,21 @@ array(
         )
     )
     3: Stmt_Expression(
-        expr: Expr_Cast_Double(
+        expr: Expr_Cast_Float(
             expr: Expr_Variable(
                 name: a
             )
         )
     )
     4: Stmt_Expression(
-        expr: Expr_Cast_Double(
+        expr: Expr_Cast_Float(
             expr: Expr_Variable(
                 name: a
             )
         )
     )
     5: Stmt_Expression(
-        expr: Expr_Cast_Double(
+        expr: Expr_Cast_Float(
             expr: Expr_Variable(
                 name: a
             )


### PR DESCRIPTION
With PHP's `(double)` cast being deprecated and already having only been an alias for the `(float)` cast, introduce `Float_` as a replacement for the `Double` cast.