### PR TITLE
Format-preserving pretty-printing with replacing expression nodes doesn't work

### DIFF
--- a/test/code/formatPreservation/replaceMinusWithFormatting.test
+++ b/test/code/formatPreservation/replaceMinusWithFormatting.test
@@ -1,0 +1,15 @@
+Test format is preserved when - is replaced with +
+-----
+<?php
+echo
+    1
+        +
+            2;
+-----
+$stmts[0]->exprs[0] = new Node\Expr\BinaryOp\Minus($stmts[0]->exprs[0]->left, $stmts[0]->exprs[0]->right);
+-----
+<?php
+echo
+    1
+        -
+            2;


### PR DESCRIPTION
Hello,

at [Infection](https://github.com/infection/infection), we do a lot of nodes replacements during the Mutation Testing process.

For example (see tests in this PR), we replace `+` with `-`.

So for the following code:

```php
<?php
echo
    1
        +
            2;
```

I would expect the following result:

```php
<?php
echo
    1
        -
            2;
```

However, as PHPUnit test failure says, we get:

```diff
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
 '<?php
 echo
-    1
-        -
-            2;'
+    1 - 2;'
```

So basically formatting disappears and we get 

```php
<?php

echo 
    1 - 2;
```

Notes: the same code **saves** formatting when we replace number with another one, not the `+` expression. It is tested here:

https://github.com/nikic/PHP-Parser/blob/0da2d6679a3df45d6d720aa2e0d4568f82a32e46/test/code/formatPreservation/basic.test#L1-L19

1. Is it a bug or expected behavior?
2. Is it possible to fix in theory?

I'm working on a new update for Infection to produce format-preserved diffs for developers, and among 5000+ mutations found more interesting cases where format isn't preserved, but let's keep it simple with this one for now. If this one is a bug, I can create separate issues for other cases.