### PR TITLE
Reproducer for a bug with format-preserving printer that loses parentheses around BooleanNot expressions

### DIFF
--- a/test/code/formatPreservation/booleanReproducer.test
+++ b/test/code/formatPreservation/booleanReproducer.test
@@ -1,0 +1,12 @@
+Reproducer for a bug with boolean negations
+-----
+<?php
+
+$a = a() && b();
+-----
+$booleanAnd = $stmts[0]->expr->expr;
+$stmts[0]->expr->expr = new \PhpParser\Node\Expr\BooleanNot($booleanAnd);
+-----
+<?php
+
+$a = !(a() && b());


### PR DESCRIPTION
This is only a reproducer for the issue reported in #1119