### PR TITLE
Add getVisitorsForNode() method to NodeTraverser

### DIFF
--- a/lib/PhpParser/NodeTraverser.php
+++ b/lib/PhpParser/NodeTraverser.php
@@ -275,7 +275,7 @@ class NodeTraverser implements NodeTraverserInterface {
      *
      * @return NodeVisitor[]
      */
-    protected function getVisitorsForNode(Node $node) {
+    protected function getVisitorsForNode(Node $node): array {
         return $this->visitors;
     }
 


### PR DESCRIPTION
@TomasVotruba here for your request https://github.com/rectorphp/rector-src/pull/6232#issuecomment-3423162697

This is template config for `getVisitorsForNode()`, which on rector use case, we use for caching visitor by node.

https://github.com/rectorphp/rector-src/blob/4b30bc5d10e7c79867a6a13da3a75a1b2c844675/src/PhpParser/NodeTraverser/RectorNodeTraverser.php#L65-L82

so we can just override the method there :), we currently using vendor-patch for it:

https://github.com/rectorphp/vendor-patches/blob/18e174cbea7beaccb140cfcf03cca3097e95ee92/patches/nikic-php-parser-lib-phpparser-nodetraverser-php.patch

Original PR for this usage for caching on Rector side:

- https://github.com/rectorphp/rector-src/pull/6232