### PR TITLE
Fix variadic trailing comma printer in format preserving printer - option #2

### DIFF
--- a/lib/PhpParser/PrettyPrinterAbstract.php
+++ b/lib/PhpParser/PrettyPrinterAbstract.php
@@ -767,7 +767,7 @@ abstract class PrettyPrinterAbstract implements PrettyPrinter {
 
         $tokenCode = $this->origTokens->getTokenCode($pos, $endPos + 1, $indentAdjustment);
         if ($node instanceof Expr\CallLike && $node->isFirstClassCallable()) {
-            $tokenCode = trim($tokenCode, ',');
+            $tokenCode = str_replace(',', '', $tokenCode);
         }
 
         $result .= $tokenCode;

--- a/test/code/formatPreservation/args_to_variadic_remove_trailing_comma.test
+++ b/test/code/formatPreservation/args_to_variadic_remove_trailing_comma.test
@@ -1,18 +1,38 @@
 Replace args with VariadicPlaceholder should remove trailing comma
 -----
 <?php
+
 strlen(
     'test',
 );
 
 strlen('another',);
+
+strlen(1, 2, 3, ) > strlen(1 , 2 , 3 ,);
+
+strlen(
+    'multiple new lines'
+
+    ,
+);
 -----
 $stmts[0]->expr->args = [new Node\VariadicPlaceholder()];
 $stmts[1]->expr->args = [new Node\VariadicPlaceholder()];
+$stmts[2]->expr->right->args = [new Node\VariadicPlaceholder()];
+$stmts[3]->expr->args = [new Node\VariadicPlaceholder()];
 -----
 <?php
+
 strlen(
     ...
 );
 
 strlen(...);
+
+strlen(1, 2, 3, ) > strlen(...);
+
+strlen(
+    ...
+
+
+);


### PR DESCRIPTION
This is alternative option to https://github.com/nikic/PHP-Parser/pull/1125
that does not modify `TokenStream`, a value object that should be read-only IMO.

To run just this test:

```bash
vendor/bin/phpunit test/PhpParser/PrettyPrinterTest.php --filter "args_to"
```

@nikic Let us know whichever you prefer or if you see a better way to fix this bug :+1:  