### PR TITLE
Stop using a semicolon (;) at the end of case statements for PHP 8.5

### DIFF
--- a/bin/php-parse
+++ b/bin/php-parse
@@ -169,11 +169,11 @@ function parseArgs($args) {
                 $operations[] = 'var-dump';
                 break;
             case '--resolve-names':
-            case '-N';
+            case '-N':
                 $operations[] = 'resolve-names';
                 break;
             case '--with-column-info':
-            case '-c';
+            case '-c':
                 $attributes['with-column-info'] = true;
                 break;
             case '--with-positions':
@@ -185,7 +185,7 @@ function parseArgs($args) {
                 $attributes['with-recovery'] = true;
                 break;
             case '--help':
-            case '-h';
+            case '-h':
                 showHelp();
                 break;
             case '--':


### PR DESCRIPTION
Thank you for your developing!

This PR improves compatibility with PHP 8.5 in bin/php-parse.

Terminating case statements with a semicolon instead of a colon has been deprecated in PHP 8.5.
https://www.php.net/manual/en/migration85.deprecated.php#migration85.deprecated.core.case-statements-with-semicolon

Results of testing with PHP Parser 5.6.2 and PHP 8.5.0:
```
% php -v | head -n 1                      
PHP 8.5.0 (cli) (built: Nov 18 2025 08:02:20) (NTS)
% ./vendor/bin/php-parse '<?php (float)1;'
PHP Deprecated:  Case statements followed by a semicolon (;) are deprecated, use a colon (:) instead in /path/to/vendor/nikic/php-parser/bin/php-parse on line 172

Deprecated: Case statements followed by a semicolon (;) are deprecated, use a colon (:) instead in /path/to/vendor/nikic/php-parser/bin/php-parse on line 172
PHP Deprecated:  Case statements followed by a semicolon (;) are deprecated, use a colon (:) instead in /path/to/vendor/nikic/php-parser/bin/php-parse on line 176

Deprecated: Case statements followed by a semicolon (;) are deprecated, use a colon (:) instead in /path/to/vendor/nikic/php-parser/bin/php-parse on line 176
PHP Deprecated:  Case statements followed by a semicolon (;) are deprecated, use a colon (:) instead in /path/to/vendor/nikic/php-parser/bin/php-parse on line 188

Deprecated: Case statements followed by a semicolon (;) are deprecated, use a colon (:) instead in /path/to/vendor/nikic/php-parser/bin/php-parse on line 188
====> Code <?php (float)1;
==> Node dump:
array(
    0: Stmt_Expression(
        expr: Expr_Cast_Double(
            expr: Scalar_Int(
                value: 1
            )
        )
    )
)
```

I would be happy if this PR could help solve the issue.

Thank you.