### PR TITLE
Add arg on new without parentheses should add ) close

### DIFF
--- a/test/code/formatPreservation/addArgNewWithoutParentheses.test
+++ b/test/code/formatPreservation/addArgNewWithoutParentheses.test
@@ -1,0 +1,9 @@
+Add Arg New Without Parentheses
+-----
+<?php
+new DateTime;
+-----
+$stmts[0]->expr->args = [new Node\Arg(new Scalar\String_('now'))];
+-----
+<?php
+new DateTime('now');


### PR DESCRIPTION
@TomasVotruba this is detected on our rector-symfony rule:

- https://github.com/rectorphp/rector-symfony/pull/897

```diff
-new DateTime('now');
+new DateTime('now';
```

can be run with:

```diff
vendor/bin/phpunit test/PhpParser/PrettyPrinterTest.php --filter "addArgNewWithoutParentheses" 
PHPUnit 9.6.29 by Sebastian Bergmann and contributors.

F                                                                   1 / 1 (100%)

Time: 00:00.007, Memory: 12.00 MB

There was 1 failure:

1) PhpParser\PrettyPrinterTest::testFormatPreservingPrint with data set "Users/samsonasik/www/PHP-Parser/test/code/formatPreservation/addArgNewWithoutParentheses.test#0" ('Add Arg New Without Parenthes....test)', '<?php\nnew DateTime;', '$stmts[0]->expr->args = [new ...w'))];', '<?php\nnew DateTime('now');', null)
Add Arg New Without Parentheses (/Users/samsonasik/www/PHP-Parser/test/code/formatPreservation/addArgNewWithoutParentheses.test)
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
 '<?php
-new DateTime('now');'
+new DateTime'now'<?php
+new DateTime;'

/Users/samsonasik/www/PHP-Parser/test/PhpParser/PrettyPrinterTest.php:236

FAILURES!
Tests: 1, Assertions: 1, Failures: 1.
```

that only green when using `()` on the very first.

which new without parentheses got invalid diff, and we tricked to set origNode null there.

This test for it, hopefully can be fixed here instead.