### PR TITLE
Do not try to re-clone already has origNode on CloningVisitor

### DIFF
--- a/lib/PhpParser/NodeVisitor/CloningVisitor.php
+++ b/lib/PhpParser/NodeVisitor/CloningVisitor.php
@@ -12,6 +12,10 @@ use PhpParser\NodeVisitorAbstract;
  */
 class CloningVisitor extends NodeVisitorAbstract {
     public function enterNode(Node $origNode) {
+        if ($origNode->hasAttribute('origNode')) {
+            return null;
+        }
+
         $node = clone $origNode;
         $node->setAttribute('origNode', $origNode);
         return $node;


### PR DESCRIPTION
On `CloningVisitor`, it always try to clone itself, whenever it already has `origNode` or not. 

This PR try to not re-clone when it already has an `origNode` attribute, whenever the value is set, it should already no more clone.

I reproduce the re-clone on rector usage when running unit test, it got test that shows it double cloned on rector-src /cc @TomasVotruba 