### PR TITLE
Remove assert() on CallLike::getArgs(), returns empty array on first class callable

### DIFF
--- a/lib/PhpParser/Node/Expr/CallLike.php
+++ b/lib/PhpParser/Node/Expr/CallLike.php
@@ -24,12 +24,14 @@ abstract class CallLike extends Expr {
     }
 
     /**
-     * Assert that this is not a first-class callable and return only ordinary Args.
+     * Return only ordinary Args.
      *
      * @return Arg[]
      */
     public function getArgs(): array {
-        assert(!$this->isFirstClassCallable());
+        if ($this->isFirstClassCallable()) {
+            return [];
+        }
         return $this->getRawArgs();
     }
 


### PR DESCRIPTION
In tools like `Rector` and `PHPStan`, we use `getArgs()` a lot, which it will trigger assert error:

```
There was 1 failure:

1) Rector\Tests\Php73\Rector\FuncCall\SetcookieRector\SetCookieRectorTest::test#1 with data ('/Users/samsonasik/www/rector-...hp.inc')
assert(!$this->isFirstClassCallable())

/Users/samsonasik/www/rector-src/vendor/nikic/php-parser/lib/PhpParser/Node/Expr/CallLike.php:32
```

when enabling:

```
ini-values: zend.assertions=1
```

I think to avoid repetitive check:

```php
        if ($node->isFirstClassCallable()) {
              return null;
        }

       $args = $node->getArgs();
```

We can carefully check that, but sometime, we forgot.

I think the returns can be early return empty array when it is first class callable.

User that want to get both `Arg` and `VariadicPlaceholder` can use `->args` public property instead.

/cc @TomasVotruba @ondrejmirtes @ruudk @staabm 