### PR TITLE
Add missing label characters in PrettyPrinterAbstract::$labelCharMap

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,7 @@
     "require": {
         "php": ">=7.4",
         "ext-tokenizer": "*",
-        "ext-json": "*",
-        "ext-ctype": "*"
+        "ext-json": "*"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0",

--- a/lib/PhpParser/PrettyPrinterAbstract.php
+++ b/lib/PhpParser/PrettyPrinterAbstract.php
@@ -1309,7 +1309,7 @@ abstract class PrettyPrinterAbstract implements PrettyPrinter {
         $this->labelCharMap = [];
         for ($i = 0; $i < 256; $i++) {
             $chr = chr($i);
-            $this->labelCharMap[$chr] = $i >= 0x80 || ctype_alnum($chr);
+            $this->labelCharMap[$chr] = (bool) preg_match('/^[a-zA-Z0-9_\x80-\xff]$/', $chr);
         }
 
         if ($this->phpVersion->allowsDelInIdentifiers()) {

--- a/test/code/formatPreservation/basic.test
+++ b/test/code/formatPreservation/basic.test
@@ -188,3 +188,11 @@ echo "{$bar}bar";
 ,$b
 ,
 ,] = $b;
+-----
+<?php
+echo$a;
+-----
+$stmts[0]->exprs[0] = new Expr\ConstFetch(new Node\Name('_'));
+-----
+<?php
+echo _;


### PR DESCRIPTION
The underscore was missing from the list. The fix borrows the existing regular expression in `NullsafeTokenEmulator`.

As a side-effect, the only use of the ext/ctype extension has been removed, allowing the removal of the dependency on this (technically optional) extension.