### PR TITLE
NodeVisitorAbstract: inheritDoc comments

### DIFF
--- a/lib/PhpParser/NodeVisitorAbstract.php
+++ b/lib/PhpParser/NodeVisitorAbstract.php
@@ -6,18 +6,27 @@ namespace PhpParser;
  * @codeCoverageIgnore
  */
 abstract class NodeVisitorAbstract implements NodeVisitor {
+    /**
+     * @inheritDoc
+     */
     public function beforeTraverse(array $nodes) {
         return null;
     }
-
+    /**
+     * @inheritDoc
+     */
     public function enterNode(Node $node) {
         return null;
     }
-
+    /**
+     * @inheritDoc
+     */
     public function leaveNode(Node $node) {
         return null;
     }
-
+    /**
+     * @inheritDoc
+     */
     public function afterTraverse(array $nodes) {
         return null;
     }


### PR DESCRIPTION
This should help IDEs to recognize the type by propagating the type in the docstring.
Seems to help my IntelliJ.