### PR TITLE
Fix three engine-conformance divergences in the lexer and string parser

### DIFF
--- a/lib/PhpParser/Lexer/TokenEmulator/VoidCastEmulator.php
+++ b/lib/PhpParser/Lexer/TokenEmulator/VoidCastEmulator.php
@@ -24,7 +24,7 @@ class VoidCastEmulator extends TokenEmulator {
             $numTokens = 1;
             $text = '(';
             $j = $i + 1;
-            if ($j < $c && $tokens[$j]->id === \T_WHITESPACE && preg_match('/[ \t]+/', $tokens[$j]->text)) {
+            if ($j < $c && $tokens[$j]->id === \T_WHITESPACE && preg_match('/\A[ \t]+\z/', $tokens[$j]->text)) {
                 $text .= $tokens[$j]->text;
                 $numTokens++;
                 $j++;
@@ -37,7 +37,7 @@ class VoidCastEmulator extends TokenEmulator {
             $text .= $tokens[$j]->text;
             $numTokens++;
             $k = $j + 1;
-            if ($k < $c && $tokens[$k]->id === \T_WHITESPACE && preg_match('/[ \t]+/', $tokens[$k]->text)) {
+            if ($k < $c && $tokens[$k]->id === \T_WHITESPACE && preg_match('/\A[ \t]+\z/', $tokens[$k]->text)) {
                 $text .= $tokens[$k]->text;
                 $numTokens++;
                 $k++;

--- a/lib/PhpParser/Node/Scalar/String_.php
+++ b/lib/PhpParser/Node/Scalar/String_.php
@@ -148,7 +148,7 @@ class String_ extends Scalar {
         if ($num <= 0xFFFF) {
             return chr(($num >> 12) + 0xE0) . chr((($num >> 6) & 0x3F) + 0x80) . chr(($num & 0x3F) + 0x80);
         }
-        if ($num <= 0x1FFFFF) {
+        if ($num <= 0x10FFFF) {
             return chr(($num >> 18) + 0xF0) . chr((($num >> 12) & 0x3F) + 0x80)
                  . chr((($num >> 6) & 0x3F) + 0x80) . chr(($num & 0x3F) + 0x80);
         }

--- a/test/PhpParser/Lexer/EmulativeTest.php
+++ b/test/PhpParser/Lexer/EmulativeTest.php
@@ -531,6 +531,29 @@ class EmulativeTest extends LexerTest {
                 [\T_STRING, 'VOID'],
                 [\ord(')'), ')'],
             ]],
+            // A void cast whose interior whitespace contains a newline is not a cast
+            // in the engine, so it must not be emulated as one -- even when a real
+            // void cast elsewhere in the file arms the emulator.
+            ['8.5', "(void)1; ( \nvoid)1;", [
+                [\T_VOID_CAST, '(void)'],
+                [\T_LNUMBER, '1'],
+                [\ord(';'), ';'],
+                [\ord('('), '('],
+                [\T_STRING, 'void'],
+                [\ord(')'), ')'],
+                [\T_LNUMBER, '1'],
+                [\ord(';'), ';'],
+            ]],
+            ['8.5', "(void)1; (void \n)1;", [
+                [\T_VOID_CAST, '(void)'],
+                [\T_LNUMBER, '1'],
+                [\ord(';'), ';'],
+                [\ord('('), '('],
+                [\T_STRING, 'void'],
+                [\ord(')'), ')'],
+                [\T_LNUMBER, '1'],
+                [\ord(';'), ';'],
+            ]],
         ];
     }
 }

--- a/test/code/parser/scalar/unicodeEscape.test
+++ b/test/code/parser/scalar/unicodeEscape.test
@@ -81,3 +81,8 @@ array(
 "\u{FFFFFFFFFFFFFFFF}";
 -----
 Invalid UTF-8 codepoint escape sequence: Codepoint too large on line 2
+-----
+<?php
+"\u{110000}";
+-----
+Invalid UTF-8 codepoint escape sequence: Codepoint too large on line 2


### PR DESCRIPTION
Three small, independent fixes where the parser or the emulative lexer diverges from how the PHP engine tokenizes or parses the same input. In each, PHP-Parser accepts or shapes a token the engine treats differently.

## 1. `\u{...}` accepts code points above the Unicode maximum

`String_::codePointToUtf8()` accepted code points up to `0x1FFFFF` (the largest value that fits in four UTF-8 bytes), but the maximum valid Unicode code point is `0x10FFFF`. For `"\u{110000}"` through `"\u{1FFFFF}"` the parser produced a four-byte string value, while the engine rejects the whole file with `Invalid UTF-8 codepoint escape sequence: Codepoint too large`. The existing test only covered the extreme `\u{FFFFFFFFFFFFFFFF}` overflow, so this boundary slipped through. Lowered the bound to `0x10FFFF`.

## 2. Comment between `enum` and the enum name

`EnumTokenEmulator::isKeywordContext()` recognised `enum` as a keyword only when it was immediately followed by whitespace and then the `T_STRING` name. A comment in between, such as `enum/*c*/Foo` or `enum // c` followed by a newline and the name, left `enum` as a plain identifier while the engine tokenizes it as `T_ENUM`. On an older host emulating 8.1+, that turned a valid enum declaration into a parse error. Now the lookahead skips whitespace and comments before checking for the name, matching the engine (verified against `token_get_all` for the comment, line-comment, `enum = 1`, and `enum::X` cases) and the comment handling `KeywordEmulator` already applies to the preceding token.

## 3. Void cast whose whitespace spans a newline

`VoidCastEmulator::emulate()` gated the interior whitespace of a `(void)` cast with an unanchored `/[ \t]+/`, which matches any run that merely contains a space or tab even when it also contains a newline. The engine forbids newlines inside a cast, so a run like `( \nvoid)` (when a real `(void)` elsewhere in the file arms the emulator) was wrongly merged into a single `T_VOID_CAST`. Anchored the check with `\A[ \t]+\z` so only pure space/tab runs qualify.
