### PR TITLE
Fix attribute insertion on enums in formatting-preserving printer

### DIFF
--- a/lib/PhpParser/PrettyPrinterAbstract.php
+++ b/lib/PhpParser/PrettyPrinterAbstract.php
@@ -1655,6 +1655,7 @@ abstract class PrettyPrinterAbstract implements PrettyPrinter {
             Stmt\Function_::class . '->params' => ['(', '', ''],
             Stmt\Interface_::class . '->attrGroups' => [null, '', "\n"],
             Stmt\Class_::class . '->attrGroups' => [null, '', "\n"],
+            Stmt\Enum_::class . '->attrGroups' => [null, '', "\n"],
             Stmt\ClassConst::class . '->attrGroups' => [null, '', "\n"],
             Stmt\ClassMethod::class . '->attrGroups' => [null, '', "\n"],
             Stmt\Function_::class . '->attrGroups' => [null, '', "\n"],

--- a/test/code/formatPreservation/attributes.test
+++ b/test/code/formatPreservation/attributes.test
@@ -176,3 +176,27 @@ class X {};
     C,
 ]
 class X {};
+-----
+<?php
+enum E {
+    case A;
+    case B;
+
+    case C;
+}
+-----
+$attrGroup = new Node\AttributeGroup([
+    new Node\Attribute(new Node\Name('X'), []),
+]);
+$stmts[0]->attrGroups[] = $attrGroup;
+$stmts[0]->stmts[0]->attrGroups[] = $attrGroup;
+-----
+<?php
+#[X]
+enum E {
+    #[X]
+    case A;
+    case B;
+
+    case C;
+}


### PR DESCRIPTION
Currently, the code is formatted to:
```
<?php
#[X]
enum E {
    #[X]
    case A;
    case B;
    case C;
}