### PR TITLE
Fix attribute insertion on enum cases in formatting-preserving printer

### DIFF
--- a/lib/PhpParser/PrettyPrinterAbstract.php
+++ b/lib/PhpParser/PrettyPrinterAbstract.php
@@ -1656,6 +1656,7 @@ abstract class PrettyPrinterAbstract implements PrettyPrinter {
             Stmt\Interface_::class . '->attrGroups' => [null, '', "\n"],
             Stmt\Class_::class . '->attrGroups' => [null, '', "\n"],
             Stmt\Enum_::class . '->attrGroups' => [null, '', "\n"],
+            Stmt\EnumCase::class . '->attrGroups' => [null, '', "\n"],
             Stmt\ClassConst::class . '->attrGroups' => [null, '', "\n"],
             Stmt\ClassMethod::class . '->attrGroups' => [null, '', "\n"],
             Stmt\Function_::class . '->attrGroups' => [null, '', "\n"],

--- a/test/code/formatPreservation/attributes.test
+++ b/test/code/formatPreservation/attributes.test
@@ -200,3 +200,21 @@ enum E {
 
     case C;
 }
+-----
+<?php
+enum E: int {
+    case AAAA = 1;
+    case B    = 2;
+}
+-----
+$attrGroup = new Node\AttributeGroup([
+    new Node\Attribute(new Node\Name('X'), []),
+]);
+$stmts[0]->stmts[1]->attrGroups[] = $attrGroup;
+-----
+<?php
+enum E: int {
+    case AAAA = 1;
+    #[X]
+    case B    = 2;
+}


### PR DESCRIPTION
Currently, the code is formatted to:
```php
<?php
enum E: int {
    case AAAA = 1;
    #[X]
    case B = 2;
}
