### PR TITLE
Cheap check first in `dereferenceLhsRequiresParens()`

### DIFF
--- a/lib/PhpParser/PrettyPrinterAbstract.php
+++ b/lib/PhpParser/PrettyPrinterAbstract.php
@@ -1186,8 +1186,8 @@ abstract class PrettyPrinterAbstract implements PrettyPrinter {
      */
     protected function dereferenceLhsRequiresParens(Node $node): bool {
         // A constant can occur on the LHS of an array/object deref, but not a static deref.
-        return $this->staticDereferenceLhsRequiresParens($node)
-            && !$node instanceof Expr\ConstFetch;
+        return !$node instanceof Expr\ConstFetch &&
+            $this->staticDereferenceLhsRequiresParens($node);
     }
 
     /**


### PR DESCRIPTION
do simple bool comparison before going the more expensive route via another method call

born from a PHPStan case in which pretty printing of a files expressions turn into the main bottleneck
<img width="116" height="440" alt="grafik" src="https://github.com/user-attachments/assets/5f094849-2620-43b7-bcfc-4912045117ad" />

repro:
run phpstan on https://github.com/phpstan/phpstan-src/blob/7e97b9e67a506cd056ed3f34ad739a388c6d7942/tests/bench/data/nullsafe-chain-walk.php like 
`phpstan analyze nullsafe-chain-walk.php --debug`

----

this PR does not resolve this bottleneck though