### PR TITLE
Use iteration over recursion in `PrettyPrinterAbstract::newOperandRequiresParens()`

### DIFF
--- a/lib/PhpParser/PrettyPrinterAbstract.php
+++ b/lib/PhpParser/PrettyPrinterAbstract.php
@@ -1224,18 +1224,22 @@ abstract class PrettyPrinterAbstract implements PrettyPrinter {
      * @return bool Whether parentheses are required
      */
     protected function newOperandRequiresParens(Node $node): bool {
-        if ($node instanceof Node\Name || $node instanceof Expr\Variable) {
-            return false;
+        while (true) {
+            if ($node instanceof Node\Name || $node instanceof Expr\Variable) {
+                return false;
+            }
+            if ($node instanceof Expr\ArrayDimFetch || $node instanceof Expr\PropertyFetch ||
+                $node instanceof Expr\NullsafePropertyFetch
+            ) {
+                $node = $node->var;
+                continue;
+            }
+            if ($node instanceof Expr\StaticPropertyFetch) {
+                $node = $node->class;
+                continue;
+            }
+            return true;
         }
-        if ($node instanceof Expr\ArrayDimFetch || $node instanceof Expr\PropertyFetch ||
-            $node instanceof Expr\NullsafePropertyFetch
-        ) {
-            return $this->newOperandRequiresParens($node->var);
-        }
-        if ($node instanceof Expr\StaticPropertyFetch) {
-            return $this->newOperandRequiresParens($node->class);
-        }
-        return true;
     }
 
     /**


### PR DESCRIPTION
in the profile from https://github.com/nikic/PHP-Parser/pull/1160 we can see that pretty printing complex expression can easily get really deep into recursion.

while I do not have a reproducer affecting `newOperandRequiresParens` implementation wise its a easy candidate to prevent recursion on and use iteration instead.

this PR here is similar to/inspired by https://github.com/phpstan/phpstan-src/pull/6084 in which we saw some perf benefits of using a loop over recursion