### PR TITLE
Fix inclusive endFilePos in unterminated comment error range

### DIFF
--- a/lib/PhpParser/Lexer.php
+++ b/lib/PhpParser/Lexer.php
@@ -102,11 +102,16 @@ class Lexer {
         // Check for unterminated comment
         $lastToken = $tokens[$numTokens - 1];
         if ($this->isUnterminatedComment($lastToken)) {
+            // endFilePos is inclusive, unlike the exclusive getEndPos(). An unterminated comment
+            // is the one comment token that can end on a newline, and a range ending on a line
+            // terminator has no column, so the reported range stops at the last content
+            // character instead.
+            $text = \rtrim($lastToken->text, "\r\n");
             $errorHandler->handleError(new Error('Unterminated comment', [
                 'startLine' => $lastToken->line,
-                'endLine' => $lastToken->getEndLine(),
+                'endLine' => $lastToken->line + \substr_count($text, "\n"),
                 'startFilePos' => $lastToken->pos,
-                'endFilePos' => $lastToken->getEndPos(),
+                'endFilePos' => $lastToken->pos + \strlen($text) - 1,
             ]));
         }
 

--- a/test/PhpParser/LexerTest.php
+++ b/test/PhpParser/LexerTest.php
@@ -31,8 +31,8 @@ class LexerTest extends \PHPUnit\Framework\TestCase {
 
     public static function provideTestError() {
         return [
-            ["<?php /*", ["Unterminated comment from 1:7 to 1:9"]],
-            ["<?php /*\n", ["Unterminated comment from 1:7 to 2:1"]],
+            ["<?php /*", ["Unterminated comment from 1:7 to 1:8"]],
+            ["<?php /*\n", ["Unterminated comment from 1:7 to 1:8"]],
             ["<?php \1", ["Unexpected character \"\1\" (ASCII 1) from 1:7 to 1:7"]],
             ["<?php \0", ["Unexpected null byte from 1:7 to 1:7"]],
             // Error with potentially emulated token
@@ -40,7 +40,7 @@ class LexerTest extends \PHPUnit\Framework\TestCase {
             ["<?php\n\0\1 foo /* bar", [
                 "Unexpected null byte from 2:1 to 2:1",
                 "Unexpected character \"\1\" (ASCII 1) from 2:2 to 2:2",
-                "Unterminated comment from 2:8 to 2:14"
+                "Unterminated comment from 2:8 to 2:13"
             ]],
         ];
     }

--- a/test/code/parser/errorHandling/lexerErrors.test
+++ b/test/code/parser/errorHandling/lexerErrors.test
@@ -6,7 +6,7 @@ $a = 42;
 /*
 $b = 24;
 -----
-Unterminated comment from 4:1 to 5:9
+Unterminated comment from 4:1 to 5:8
 array(
     0: Stmt_Expression(
         expr: Expr_Assign(
@@ -139,5 +139,5 @@ if ($b) {
     /* unterminated
 }
 -----
-Unterminated comment from 5:5 to 6:2
+Unterminated comment from 5:5 to 6:1
 Syntax error, unexpected EOF from 6:2 to 6:2


### PR DESCRIPTION
`doc/component/Lexer.markdown` defines `endFilePos` as "Offset into the code string of the last character that is part of the node". The unterminated-comment error passes `Token::getEndPos()`, which is `$this->pos + \strlen($this->text)` - one past the last byte.

The reported end column is therefore outside the input:

```
'<?php /*'              8 bytes -> Unterminated comment from 1:7 to 1:9
'<?php /*\n'            9 bytes -> Unterminated comment from 1:7 to 2:1
'<?php $x = 1; /* abc' 20 bytes -> Unterminated comment from 1:15 to 1:21
```

An 8-byte input has no column 9, and the second case reports a position on line 2 of a file whose line 2 is empty.

Every other error site writes this attribute inclusively - `Lexer.php:56` passes `$token->pos`, `ParserAbstract.php:497` uses `$afterEndToken->pos - 1`, `ParserAbstract.php:519` passes `$token->pos`. This is the one site that does not.

`getEndPos() - 1` alone is not enough, because the comment token includes its trailing newline when the input ends in one:

```
bare getEndPos()-1 -> byte 8 = '\n', column 9 on a line of 8 characters
with rtrim         -> byte 7 = '*',  column 8
```

A position on a line terminator has no meaningful column, so the range stops at the last content character and `endLine` is derived from the same text.

## Verification

`LexerTest::testError` already covers these inputs, so no new test is added. Three of its expectations recorded the old values, which is why the suite was green over this. Both halves are load-bearing, proven on `master`:

| tree | result |
|---|---|
| `master`, untouched | OK (1895 tests, 2766 assertions) |
| fix only, expectations left alone | 8 failures |
| expectations only, fix reverted | 8 failures |
| both | OK (1895 tests, 2766 assertions) |

```
1) PhpParser\LexerTest::testError with data set #0
   ('<?php /*', array('Unterminated comment from 1:7 to 1:9'))
-'Unterminated comment from 1:7 to 1:9'
+'Unterminated comment from 1:7 to 1:8'
```

`test_old/run-php-src.sh 7.4.33` exits 0 over 14,695 files with no format-preserving mismatches, on PHP 8.5.4.
