### PR TITLE
perf: Skip escape sequence processing for strings without backslashes

### DIFF
--- a/lib/PhpParser/Node/Scalar/String_.php
+++ b/lib/PhpParser/Node/Scalar/String_.php
@@ -77,12 +77,12 @@ class String_ extends Scalar {
         $quote = $str[$bLength];
         $str = substr($str, $bLength + 1, -1);
 
-        // Fast path: a string without any backslash contains no escape sequences.
-        if (false === strpos($str, '\\')) {
-            return $str;
-        }
-
         if ('\'' === $quote) {
+            // Fast path: a string without any backslash contains no escape sequences.
+            if (false === strpos($str, '\\')) {
+                return $str;
+            }
+
             return str_replace(
                 ['\\\\', '\\\''],
                 ['\\', '\''],

--- a/lib/PhpParser/Node/Scalar/String_.php
+++ b/lib/PhpParser/Node/Scalar/String_.php
@@ -74,17 +74,23 @@ class String_ extends Scalar {
             $bLength = 1;
         }
 
-        if ('\'' === $str[$bLength]) {
+        $quote = $str[$bLength];
+        $str = substr($str, $bLength + 1, -1);
+
+        // Fast path: a string without any backslash contains no escape sequences.
+        if (false === strpos($str, '\\')) {
+            return $str;
+        }
+
+        if ('\'' === $quote) {
             return str_replace(
                 ['\\\\', '\\\''],
                 ['\\', '\''],
-                substr($str, $bLength + 1, -1)
-            );
-        } else {
-            return self::parseEscapeSequences(
-                substr($str, $bLength + 1, -1), '"', $parseUnicodeEscape
+                $str
             );
         }
+
+        return self::parseEscapeSequences($str, '"', $parseUnicodeEscape);
     }
 
     /**
@@ -99,6 +105,11 @@ class String_ extends Scalar {
      * @return string String with escape sequences parsed
      */
     public static function parseEscapeSequences(string $str, ?string $quote, bool $parseUnicodeEscape = true): string {
+        // Fast path: a string without any backslash contains no escape sequences.
+        if (false === strpos($str, '\\')) {
+            return $str;
+        }
+
         if (null !== $quote) {
             $str = str_replace('\\' . $quote, $quote, $str);
         }


### PR DESCRIPTION
`String_::parse()` always ran `str_replace()` for single-quoted strings and `str_replace()` + `preg_replace_callback()` for double-quoted strings, even when the literal contained no backslash and there was nothing to unescape. 

This PR skips escape sequence processing for strings without backslashes.

Tested on php-parser vendor, laravel framework, and coolify, it shows faster:

Corpus | Double-quoted tokens | parse() gain (function-level, double-quoted only)
-- | -- | --
PHP-Parser vendor | 2,105 | 1.70 → 1.27 ms (~25%)
laravel-framework | 9,157 | 10.66 → 10.07 ms (~5.5%)
coolify (Laravel app + vendor) | 148,958 | 166.6 → 164.5 ms (~1.3%)
